### PR TITLE
Add SkillsJars, javadocs.dev MCP server; refocus Code Assistants on Java dev technologies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# AI4JVM - Project Guidelines
+
+## About
+
+AI4JVM is a curated guide to the Java AI ecosystem — a single-page website (`index.html`) covering agent frameworks, inference engines, code assistants, key people, and learning resources.
+
+## Code Assistants Section Focus
+
+The "Java with Code Assistants" section emphasizes **technologies that enhance Java development when used alongside AI code assistants**, not just the assistants themselves. This includes:
+
+- **MCP servers** that give AI agents access to Java-specific context (e.g., javadocs.dev for live Javadoc browsing)
+- **SkillsJars** — reusable skill packages (Maven/Gradle JARs containing `SKILL.md` files) that teach AI agents Java patterns and best practices
+- **AI coding assistants** with strong Java support (Claude Code, GitHub Copilot, JetBrains AI, Amazon Q)
+
+When adding new entries to this section, prioritize tools and technologies that bridge the gap between AI assistants and the Java ecosystem — MCP servers, skill registries, IDE plugins, and context providers — over general-purpose AI tools.
+
+## Structure
+
+- `index.html` — the entire site (HTML + CSS, no build step)
+- Sections: News, Agent Frameworks, Code Assistants, Inference & Training, People, Resources
+- Dark theme with card-based layout
+
+## Style
+
+- Cards use badge classes: `badge-framework`, `badge-inference`, `badge-assistant`, `badge-resource`
+- Each card has a title, description, and links (Docs, GitHub, Website, etc.)
+- Keep descriptions concise (2-3 sentences) and factual

--- a/index.html
+++ b/index.html
@@ -354,17 +354,39 @@
 
 <hr class="section-divider">
 
-<!-- CODE ASSISTANTS -->
+<!-- CODE ASSISTANTS & JAVA DEV TOOLS -->
 <section id="assistants">
   <div class="container">
     <h2 class="section-title">Java with Code Assistants</h2>
-    <p class="section-subtitle">AI-powered tools that make Java development faster and more productive.</p>
+    <p class="section-subtitle">Technologies that supercharge Java development when paired with AI code assistants &mdash; from MCP servers that give agents live Javadoc access, to reusable skill packages and IDE integrations.</p>
     <div class="card-grid">
+
+      <div class="card">
+        <span class="card-badge badge-assistant">MCP Server</span>
+        <h3>Javadocs.dev MCP Server</h3>
+        <p>Gives AI assistants live access to Java, Kotlin, and Scala library documentation from Maven Central. Six tools including latest-version lookup, Javadoc symbol browsing, and source file retrieval. Connect any MCP client via Streamable HTTP.</p>
+        <div class="card-links">
+          <a href="https://www.javadocs.dev/mcp">Connect (MCP)</a>
+          <a href="https://hub.docker.com/mcp/server/javadocs/overview">Docker MCP</a>
+          <a href="https://github.com/jamesward/javadoccentral">GitHub</a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-assistant">Skills</span>
+        <h3>SkillsJars</h3>
+        <p>A packaging format and registry for distributing reusable AI agent skills as Maven/Gradle JARs. Skills are Markdown files (<code>SKILL.md</code>) under <code>META-INF/skills/</code> that teach AI agents domain-specific patterns. Discover and load skills on demand in Claude Code, Kiro, and Spring AI apps.</p>
+        <div class="card-links">
+          <a href="https://www.skillsjars.com/">Registry</a>
+          <a href="https://github.com/spring-ai-community/spring-ai-agent-utils">Agent Utils</a>
+          <a href="https://github.com/spring-ai-community/spring-testing-skills">Testing Skills</a>
+        </div>
+      </div>
 
       <div class="card">
         <span class="card-badge badge-assistant">Assistant</span>
         <h3>Claude Code</h3>
-        <p>Anthropic's agentic coding tool, right in your terminal. Understands entire codebases, makes multi-file changes, runs tests, and iterates. Java's strict type system catches AI mistakes at compile time, making it an ideal pairing.</p>
+        <p>Anthropic's agentic coding tool, right in your terminal. Understands entire codebases, makes multi-file changes, runs tests, and iterates. Java's strict type system catches AI mistakes at compile time, making it an ideal pairing. Supports MCP servers and SkillsJars for extended Java context.</p>
         <div class="card-links">
           <a href="https://code.claude.com/docs/en/overview">Docs</a>
         </div>
@@ -373,7 +395,7 @@
       <div class="card">
         <span class="card-badge badge-assistant">Assistant</span>
         <h3>GitHub Copilot</h3>
-        <p>Inline code completions and chat powered by LLMs. Excellent Java support in VS Code and JetBrains IDEs. Understands Spring Boot patterns, JPA entities, and Stream API fluently. Agent mode for multi-step tasks.</p>
+        <p>Inline code completions and chat powered by LLMs. Excellent Java support in VS Code and JetBrains IDEs. Understands Spring Boot patterns, JPA entities, and Stream API fluently. Agent mode for multi-step tasks with MCP server support.</p>
         <div class="card-links">
           <a href="https://github.com/features/copilot">Website</a>
         </div>


### PR DESCRIPTION
Restructure the Code Assistants section to emphasize technologies that
enhance Java development alongside AI assistants — MCP servers, skill
packages, and IDE integrations — not just the assistants themselves.

- Add javadocs.dev MCP Server card (live Javadoc access for AI agents)
- Add SkillsJars card (reusable AI agent skills as Maven/Gradle JARs)
- Update section subtitle and descriptions to reflect the broader focus
- Note MCP support in Claude Code and GitHub Copilot descriptions
- Create CLAUDE.md documenting the Java development tools focus

https://claude.ai/code/session_01Ggwrup987DFMrVUcJwemWA