### PR TITLE
Add Oleg Šelajev to contributors list

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -255,6 +255,15 @@ Notes:
 - **Role:** Developer Advocate at Neo4j
 - **Links:** [@JMHReif](https://twitter.com/JMHReif) · [GitHub](https://github.com/JMHReif) · [LinkedIn](https://www.linkedin.com/in/jmhreif/) · [Website](https://jmhreif.com)
 
+### Oleg Šelajev
+
+- **Badge:** Person
+- **Java Champion**
+- **Initials:** OŠ
+- **Photo:** https://avatars.githubusercontent.com/u/426039?v=4
+- **Role:** Developer Relations Lead for AI — Docker
+- **Links:** [@shelajev](https://twitter.com/shelajev) · [GitHub](https://github.com/shelajev) · [LinkedIn](https://www.linkedin.com/in/shelajev/)
+
 ### Bartosz Sorrentino
 
 - **Badge:** Person

--- a/index.html
+++ b/index.html
@@ -710,6 +710,20 @@
       </div>
 
       <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/426039?v=4" alt="Oleg Šelajev"></div>
+        <div class="person-info">
+          <h4>Oleg Šelajev</h4>
+          <span class="badge-champion">Java Champion</span>
+          <p>Developer Relations Lead for AI &mdash; Docker</p>
+          <div class="person-links">
+            <a class="icon icon-x" href="https://twitter.com/shelajev" title="@shelajev"></a>
+            <a class="icon icon-github" href="https://github.com/shelajev" title="GitHub"></a>
+            <a class="icon icon-linkedin" href="https://www.linkedin.com/in/shelajev/" title="LinkedIn"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/301596?v=4" alt="Bartosz Sorrentino"></div>
         <div class="person-info">
           <h4>Bartosz Sorrentino</h4>


### PR DESCRIPTION
## Summary
Added Oleg Šelajev, a Java Champion and Developer Relations Lead for AI at Docker, to the contributors list.

## Changes
- Added Oleg Šelajev's profile card to `index.html` with:
  - GitHub avatar image
  - Java Champion badge
  - Role: Developer Relations Lead for AI — Docker
  - Social links (Twitter, GitHub, LinkedIn)
- Updated `SPEC.md` with Oleg's profile information following the existing documentation format

## Details
Oleg's profile is positioned alphabetically in the contributors list, appearing after Jennifer Reif and before Bartosz Sorrentino. The implementation follows the established HTML structure and styling conventions used for other contributor profiles.

https://claude.ai/code/session_01BrM4vhZSRPvyAtyb4ABr4r