### PR TITLE
Add GitHub Copilot SDK for Java to SPEC.md and index.html

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -91,6 +91,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** Official Java SDK for the Claude Messages API. Streaming, retries, structured outputs, extended thinking, code execution, and files API. Build Java apps powered by Claude.
 - **Links:** [GitHub](https://github.com/anthropics/anthropic-sdk-java)
 
+### GitHub Copilot SDK for Java
+- **Badge:** SDK
+- **Description:** Official Java SDK for embedding the GitHub Copilot agentic engine directly into Java applications. Uses the same agentic harness that powers the Copilot CLI — exposes planning, tool calling, file editing, and MCP integration via a simple Java API. Currently in technical preview.
+- **Links:** [Docs](https://github.github.com/copilot-sdk-java/) · [GitHub](https://github.com/github/copilot-sdk-java)
+
 ### Tracy (JetBrains)
 - **Badge:** Library
 - **Description:** AI tracing library for Kotlin and Java. Captures structured traces from LLM interactions — messages, cost, token usage, and execution time. Implements OpenTelemetry Generative AI Semantic Conventions with exports to Langfuse, Weights & Biases, and more.

--- a/index.html
+++ b/index.html
@@ -412,6 +412,16 @@
       </div>
 
       <div class="card">
+        <span class="card-badge badge-inference">SDK</span>
+        <h3>GitHub Copilot SDK for Java</h3>
+        <p>Official Java SDK for embedding the GitHub Copilot agentic engine directly into Java applications. Uses the same agentic harness that powers the Copilot CLI &mdash; exposes planning, tool calling, file editing, and MCP integration via a simple Java API. Currently in technical preview.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://github.github.com/copilot-sdk-java/" title="Docs"></a>
+          <a class="icon icon-github" href="https://github.com/github/copilot-sdk-java" title="GitHub"></a>
+        </div>
+      </div>
+
+      <div class="card">
         <span class="card-badge badge-inference">Library</span>
         <h3>Tracy (JetBrains)</h3>
         <p>AI tracing library for Kotlin and Java. Captures structured traces from LLM interactions &mdash; messages, cost, token usage, and execution time. Implements OpenTelemetry Generative AI Semantic Conventions with exports to Langfuse, Weights &amp; Biases, and more.</p>


### PR DESCRIPTION
This pull request adds information about the GitHub Copilot SDK for Java to both the documentation and the website.