### PR TITLE
Fix broken Spring AI blog link

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -37,7 +37,7 @@ AI4JVM is a curated guide to the Java AI ecosystem — a single-page website cov
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
-- https://spring.io/blog/2026/03/16/spring-ai-2-0-0-M3-and-1-1-3-and-1-0-4-available
+- https://spring.io/blog/2026/03/17/spring-ai-2-0-0-M3-and-1-1-3-and-1-0-4-available
 - https://blog.jetbrains.com/kotlin/2026/03/introducing-tracy-the-ai-observability-library-for-kotlin/
 - https://www.tmdevlab.com/mcp-server-performance-benchmark.html
 - https://thenewstack.io/2026-java-ai-apps/

--- a/index.html
+++ b/index.html
@@ -302,7 +302,7 @@
     <div class="news-bar">
       <h3>Latest Headlines</h3>
       <ul>
-        <li><a href="https://spring.io/blog/2026/03/16/spring-ai-2-0-0-M3-and-1-1-3-and-1-0-4-available">Spring AI 2.0.0-M3, 1.1.3, and 1.0.4 Available</a> &mdash; MCP annotations moved into core, 23 new features, plus maintenance releases with bug fixes</li>
+        <li><a href="https://spring.io/blog/2026/03/17/spring-ai-2-0-0-M3-and-1-1-3-and-1-0-4-available">Spring AI 2.0.0-M3, 1.1.3, and 1.0.4 Available</a> &mdash; MCP annotations moved into core, 23 new features, plus maintenance releases with bug fixes</li>
         <li><a href="https://blog.jetbrains.com/kotlin/2026/03/introducing-tracy-the-ai-observability-library-for-kotlin/">Introducing Tracy: The AI Observability Library for Kotlin</a> &mdash; production-grade AI observability for Kotlin apps, debug failures and track LLM usage with OpenTelemetry</li>
         <li><a href="https://www.tmdevlab.com/mcp-server-performance-benchmark.html">Multi-Language MCP Server Performance Benchmark</a> &mdash; comparative analysis across Go, Java, Python, and TypeScript</li>
         <li><a href="https://thenewstack.io/2026-java-ai-apps/">2026 Java AI Apps</a> &mdash; building AI applications with Java in 2026</li>


### PR DESCRIPTION
The Spring AI blog post link had the wrong date (March 16 instead of March 17), resulting in a 404. Updated the URL in both `SPEC.md` and `index.html`.