### PR TITLE
Add jvm-skills to Java with Code Assistants section

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -146,6 +146,11 @@ Technologies that supercharge Java development when paired with AI code assistan
 - **Description:** A packaging format and registry for distributing reusable AI agent skills as Maven/Gradle JARs. Skills are Markdown files (`SKILL.md`) under `META-INF/skills/` that teach AI agents domain-specific patterns. Discover and load skills on demand in Claude Code, Kiro, and Spring AI apps.
 - **Links:** website: https://www.skillsjars.com/
 
+### jvm-skills
+- **Badge:** Skills
+- **Description:** Curated directory of AI coding skills from JVM ecosystem engineers. Opinionated best-practice guides that AI tools (Claude Code, Cursor, Copilot) use as context — covering Spring Boot, jOOQ, Testcontainers, Docker, and more. Only lists skills that teach AI something it wouldn't know on its own.
+- **Links:** [Website](https://jvmskills.com) · [GitHub](https://github.com/jvm-skills/jvm-skills)
+
 ---
 
 ## Inference & Training

--- a/index.html
+++ b/index.html
@@ -513,6 +513,16 @@
         </div>
       </div>
 
+      <div class="card">
+        <span class="card-badge badge-framework">Skills</span>
+        <h3><a href="https://jvmskills.com">jvm-skills</a></h3>
+        <p>Curated directory of AI coding skills from JVM ecosystem engineers. Opinionated best-practice guides that AI tools (Claude Code, Cursor, Copilot) use as context — covering Spring Boot, jOOQ, Testcontainers, Docker, and more. Only lists skills that teach AI something it wouldn't know on its own.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://jvmskills.com" title="Website"></a>
+          <a class="icon icon-github" href="https://github.com/jvm-skills/jvm-skills" title="GitHub"></a>
+        </div>
+      </div>
+
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- Adds [jvm-skills](https://jvmskills.com) card next to SkillsJars in the "Java with Code Assistants" section
- Updated both `SPEC.md` and `index.html`

## Test plan
- [ ] Verify the new card renders correctly in the browser
- [ ] Check links to jvmskills.com and GitHub repo work

🤖 Generated with [Claude Code](https://claude.com/claude-code)