### PR TITLE
Add JamJet — production-grade agent runtime with Java SDK

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -97,6 +97,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** Microsoft's AI orchestration SDK with first-class Java support. Provides prompt chaining, planning, memory, and agent framework abstractions with deep Azure integration.
 - **Links:** [GitHub](https://github.com/microsoft/semantic-kernel-java)
 
+### JamJet
+- **Badge:** Framework
+- **Description:** Production-grade agent runtime with native Java SDK. Rust core (Tokio) for performance, graph-based durable workflow orchestration with event-sourced state, automatic crash recovery, audit trails, and first-class human-in-the-loop. Native MCP client/server and A2A protocol support. Java SDK uses records, virtual threads, and fluent builder API. Apache 2.0.
+- **Links:** [Docs](https://docs.jamjet.dev) · [GitHub](https://github.com/jamjet-labs/jamjet) · [Examples](https://github.com/jamjet-labs/jamjet/tree/main/sdk/java/examples)
+
 ### MCP Java SDK
 - **Badge:** SDK
 - **Description:** The official Java SDK for Model Context Protocol servers and clients. Maintained by the Spring AI team. Sync/async, STDIO/SSE/Streamable HTTP transports, OAuth support via Spring integration.

--- a/index.html
+++ b/index.html
@@ -395,6 +395,17 @@
       </div>
 
       <div class="card">
+        <span class="card-badge badge-framework">Framework</span>
+        <h3><a href="https://docs.jamjet.dev">JamJet</a></h3>
+        <p>Production-grade agent runtime with native Java SDK. Rust core (Tokio) for performance, graph-based durable workflow orchestration with event-sourced state, automatic crash recovery, audit trails, and first-class human-in-the-loop. Native MCP client/server and A2A protocol support. Java SDK uses records, virtual threads, and fluent builder API. Apache 2.0.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://docs.jamjet.dev" title="Docs"></a>
+          <a class="icon icon-github" href="https://github.com/jamjet-labs/jamjet" title="GitHub"></a>
+          <a class="icon icon-web" href="https://github.com/jamjet-labs/jamjet/tree/main/sdk/java/examples" title="Examples"></a>
+        </div>
+      </div>
+
+      <div class="card">
         <span class="card-badge badge-inference">SDK</span>
         <h3><a href="https://modelcontextprotocol.io/sdk/java/mcp-overview">MCP Java SDK</a></h3>
         <p>The official Java SDK for Model Context Protocol servers and clients. Maintained by the Spring AI team. Sync/async, STDIO/SSE/Streamable HTTP transports, OAuth support via Spring integration.</p>
@@ -587,21 +598,6 @@
             <a class="icon icon-github" href="https://github.com/brunoborges" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://ca.linkedin.com/in/brunocborges" title="LinkedIn"></a>
             <a class="icon icon-web" href="https://blog.brunoborges.info/" title="Blog"></a>
-          </div>
-        </div>
-      </div>
-
-      <div class="person">
-        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/363447?v=4" alt="Eric Deandrea"></div>
-        <div class="person-info">
-          <h4>Eric Deandrea</h4>
-          <span class="badge-champion">Java Champion</span>
-          <p><a href="https://docling-project.github.io/docling-java/current">Docling Java</a> project lead, contributor to LangChain4j, Sr. Principal Software Engineer at IBM</p>
-          <div class="person-links">
-            <a class="icon icon-bluesky" href="https://bsky.app/profile/ericdeandrea.dev" title="Bluesky"></a>
-            <a class="icon icon-x" href="https://x.com/edeandrea" title="@edeandrea"></a>
-            <a class="icon icon-github" href="https://github.com/edeandrea" title="GitHub"></a>
-            <a class="icon icon-linkedin" href="https://www.linkedin.com/in/edeandrea/" title="LinkedIn"></a>
           </div>
         </div>
       </div>
@@ -864,6 +860,21 @@
             <a class="icon icon-x" href="https://x.com/mariofusco" title="@mariofusco"></a>
             <a class="icon icon-github" href="https://github.com/mariofusco" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://www.linkedin.com/in/mario-fusco-3467213/" title="LinkedIn"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/363447?v=4" alt="Eric Deandrea"></div>
+        <div class="person-info">
+          <h4>Eric Deandrea</h4>
+          <span class="badge-champion">Java Champion</span>
+          <p><a href="https://docling-project.github.io/docling-java/current">Docling Java</a> project lead, contributor to LangChain4j, Sr. Principal Software Engineer at IBM</p>
+          <div class="person-links">
+            <a class="icon icon-bluesky" href="https://bsky.app/profile/ericdeandrea.dev" title="Bluesky"></a>
+            <a class="icon icon-x" href="https://x.com/edeandrea" title="@edeandrea"></a>
+            <a class="icon icon-github" href="https://github.com/edeandrea" title="GitHub"></a>
+            <a class="icon icon-linkedin" href="https://www.linkedin.com/in/edeandrea/" title="LinkedIn"></a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## What

Adds [JamJet](https://github.com/jamjet-labs/jamjet) to the Agent Frameworks & Libraries section.

## Why

JamJet fills a gap in the current catalog: **production runtime infrastructure**. Existing entries cover model abstraction (Spring AI, LangChain4j) and orchestration (LangGraph4j, Embabel). JamJet provides the durable execution layer underneath — crash recovery, event-sourced state, audit trails, and human-in-the-loop — with a native Java SDK.

**Key details:**
- **Runtime:** Rust core (Tokio) for performance — not a Java framework wrapping an LLM
- **Java SDK:** Records, virtual threads, fluent builder API — modern Java 21+ patterns
- **Protocols:** Native MCP client/server + A2A protocol support
- **Durability:** Event-sourced workflow state — if the process crashes at step 7, execution resumes from step 7
- **License:** Apache 2.0

**Java examples included:**
- [Basic Tool Flow](https://github.com/jamjet-labs/jamjet/tree/main/sdk/java/examples/basic-tool-flow) — single agent with ReAct strategy
- [Plan and Execute](https://github.com/jamjet-labs/jamjet/tree/main/sdk/java/examples/plan-and-execute-agent) — structured research with cost constraints
- [RAG Assistant](https://github.com/jamjet-labs/jamjet/tree/main/sdk/java/examples/rag-assistant) — workflow-based and agent-based RAG
- [Vertex AI Agent](https://github.com/jamjet-labs/jamjet/tree/main/examples/vertex-ai-agents/java) — Google Gemini integration

## Contribution guidelines check

- ✅ Relevant to Java developers (native Java SDK)
- ✅ Applicable to >10% of Java devs using AI (agent orchestration + production runtime)
- ✅ Backed by public evidence (GitHub repo, docs, examples, published to Maven Central)