### PR TITLE
Use MAINTAINER_PAT for model API calls when available

### DIFF
--- a/.github/scripts/llm_with_tools.py
+++ b/.github/scripts/llm_with_tools.py
@@ -200,7 +200,7 @@ def _api_call(messages: list, github_token: str, model: str,
 # ---------------------------------------------------------------------------
 
 def run() -> str:
-    github_token = os.environ["GITHUB_TOKEN"]
+    github_token = os.environ.get("MAINTAINER_PAT") or os.environ["GITHUB_TOKEN"]
     system_prompt = os.environ["SYSTEM_PROMPT"]
     user_prompt = os.environ["USER_PROMPT"]
     model = os.environ.get("MODEL", "openai/gpt-5")

--- a/.github/workflows/contribution-review.yml
+++ b/.github/workflows/contribution-review.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Run contribution review
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAINTAINER_PAT: ${{ secrets.MAINTAINER_PAT }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           PR_NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
The GITHUB_TOKEN billing may have different limits than the PAT. Prefer MAINTAINER_PAT for model inference so billing goes through the PAT owner's account. Falls back to GITHUB_TOKEN if no PAT is set.

https://claude.ai/code/session_01WixEfW6v51pFRi1Jc5EnGx