### PR TITLE
Support org-scoped GitHub Models endpoint for paid tier

### DIFF
--- a/.github/scripts/llm_with_tools.py
+++ b/.github/scripts/llm_with_tools.py
@@ -8,6 +8,7 @@ Reads the following environment variables:
   USER_PROMPT    (required) User message passed to the model
   MODEL          (optional) Model identifier (default: openai/gpt-5)
   MAX_TOKENS     (optional) Max tokens for the final answer (default: 16384)
+  GITHUB_MODELS_ORG (optional) Org name for paid-tier endpoint
 
 Prints the final model response to stdout and exits non-zero on error.
 
@@ -24,7 +25,12 @@ import urllib.parse
 import urllib.request
 from html.parser import HTMLParser
 
-API_URL = "https://models.github.ai/inference/chat/completions"
+_MODELS_ORG = os.environ.get("GITHUB_MODELS_ORG", "")
+API_URL = (
+    f"https://models.github.ai/orgs/{_MODELS_ORG}/inference/chat/completions"
+    if _MODELS_ORG
+    else "https://models.github.ai/inference/chat/completions"
+)
 
 # How many bytes to read from a fetched page before stripping HTML/truncating.
 # Large enough to capture most useful content while avoiding huge payloads.

--- a/.github/workflows/contribution-review.yml
+++ b/.github/workflows/contribution-review.yml
@@ -44,6 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAINTAINER_PAT: ${{ secrets.MAINTAINER_PAT }}
+          GITHUB_MODELS_ORG: ${{ vars.GITHUB_MODELS_ORG }}
           BASE_REF: ${{ steps.pr.outputs.base_ref }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           PR_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/site-regen.yml
+++ b/.github/workflows/site-regen.yml
@@ -74,6 +74,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAINTAINER_PAT: ${{ secrets.MAINTAINER_PAT }}
+          GITHUB_MODELS_ORG: ${{ vars.GITHUB_MODELS_ORG }}
           HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
           HEAD_REF: ${{ steps.pr.outputs.head_ref }}
           HEAD_REPO: ${{ steps.pr.outputs.head_repo }}


### PR DESCRIPTION
The personal endpoint (/inference/) always applies free-tier limits. The org endpoint (/orgs/{ORG}/inference/) uses paid-tier limits.

Set the GITHUB_MODELS_ORG repository variable to your GitHub username or org name to use the paid endpoint.

https://claude.ai/code/session_01WixEfW6v51pFRi1Jc5EnGx