### PR TITLE
Add Kenneth Kousen to contributors list

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -372,8 +372,8 @@ Notes:
 - **Java Champion**
 - **Initials:** KK
 - **Photo:** https://avatars.githubusercontent.com/u/22784?v=4
-- **Role:** Author of *Kotlin Cookbook*, *Modern Java Recipes* & *Making Java Groovy*. O'Reilly instructor for AI + Java courses. President of Kousen IT, Inc.
-- **Links:** [@kenkousen](https://twitter.com/kenkousen) · [Bluesky](https://bsky.app/profile/kousenit.com) · [GitHub](https://github.com/kousen) · [LinkedIn](https://www.linkedin.com/in/kenkousen/) · [Website](https://www.kousenit.com/)
+- **Role:** Author of six books including *Kotlin Cookbook* and *Modern Java Recipes*. O'Reilly instructor for AI + Java courses. Professor of Practice in Computer Science at Trinity College. President of Kousen IT, Inc.
+- **Links:** [@kenkousen](https://twitter.com/kenkousen) · [Bluesky](https://bsky.app/profile/kousenit.com) · [GitHub](https://github.com/kousen) · [LinkedIn](https://www.linkedin.com/in/kenkousen/) · [Website](https://www.kousenit.com/) · [Newsletter](https://kenkousen.substack.com) · [YouTube](https://youtube.com/@talesfromthejarside)
 
 ### Guillaume Laforge
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -366,6 +366,15 @@ Notes:
 - **Role:** Creator of Spring Framework, CEO of Embabel
 - **Links:** [@springrod](https://twitter.com/springrod) · [GitHub](https://github.com/johnsonr) · [LinkedIn](https://www.linkedin.com/in/johnsonroda/) · [Blog](https://medium.com/@springrod)
 
+### Kenneth Kousen
+
+- **Badge:** Person
+- **Java Champion**
+- **Initials:** KK
+- **Photo:** https://avatars.githubusercontent.com/u/22784?v=4
+- **Role:** Author of *Kotlin Cookbook*, *Modern Java Recipes* & *Making Java Groovy*. O'Reilly instructor for AI + Java courses. President of Kousen IT, Inc.
+- **Links:** [@kenkousen](https://twitter.com/kenkousen) · [Bluesky](https://bsky.app/profile/kousenit.com) · [GitHub](https://github.com/kousen) · [LinkedIn](https://www.linkedin.com/in/kenkousen/) · [Website](https://www.kousenit.com/)
+
 ### Guillaume Laforge
 
 - **Badge:** Person

--- a/index.html
+++ b/index.html
@@ -865,13 +865,15 @@
         <div class="person-info">
           <h4>Kenneth Kousen</h4>
           <span class="badge-champion">Java Champion</span>
-          <p>Author of <em>Kotlin Cookbook</em>, <em>Modern Java Recipes</em> &amp; <em>Making Java Groovy</em>. O'Reilly instructor for AI + Java courses. President of Kousen IT, Inc.</p>
+          <p>Author of six books including <em>Kotlin Cookbook</em> and <em>Modern Java Recipes</em>. O&rsquo;Reilly instructor for AI + Java courses. Professor of Practice in Computer Science at Trinity College. President of Kousen IT, Inc.</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/kenkousen" title="@kenkousen"></a>
             <a class="icon icon-bluesky" href="https://bsky.app/profile/kousenit.com" title="Bluesky"></a>
             <a class="icon icon-github" href="https://github.com/kousen" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://www.linkedin.com/in/kenkousen/" title="LinkedIn"></a>
             <a class="icon icon-web" href="https://www.kousenit.com/" title="Website"></a>
+            <a class="icon icon-web" href="https://kenkousen.substack.com" title="Newsletter"></a>
+            <a class="icon icon-youtube" href="https://youtube.com/@talesfromthejarside" title="YouTube"></a>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -861,6 +861,22 @@
       </div>
 
       <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/22784?v=4" alt="Kenneth Kousen"></div>
+        <div class="person-info">
+          <h4>Kenneth Kousen</h4>
+          <span class="badge-champion">Java Champion</span>
+          <p>Author of <em>Kotlin Cookbook</em>, <em>Modern Java Recipes</em> &amp; <em>Making Java Groovy</em>. O'Reilly instructor for AI + Java courses. President of Kousen IT, Inc.</p>
+          <div class="person-links">
+            <a class="icon icon-x" href="https://twitter.com/kenkousen" title="@kenkousen"></a>
+            <a class="icon icon-bluesky" href="https://bsky.app/profile/kousenit.com" title="Bluesky"></a>
+            <a class="icon icon-github" href="https://github.com/kousen" title="GitHub"></a>
+            <a class="icon icon-linkedin" href="https://www.linkedin.com/in/kenkousen/" title="LinkedIn"></a>
+            <a class="icon icon-web" href="https://www.kousenit.com/" title="Website"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/47907?v=4" alt="Guillaume Laforge"></div>
         <div class="person-info">
           <h4>Guillaume Laforge</h4>


### PR DESCRIPTION
This PR adds Kenneth Kousen to the contributors/team members section of the website.

## Changes Made

- Added Kenneth Kousen's profile card to `index.html` with:
  - Profile avatar from GitHub
  - Java Champion badge
  - Bio highlighting his authorship of Kotlin Cookbook, Modern Java Recipes, and Making Java Groovy, along with his role as O'Reilly instructor and president of Kousen IT, Inc.
  - Social links: Twitter, Bluesky, GitHub, LinkedIn, and personal website

- Updated `SPEC.md` with Kenneth Kousen's entry documenting:
  - Badge type and Java Champion status
  - Initials (KK)
  - Photo URL
  - Role description
  - Social media and web links

The profile is inserted in alphabetical order between Rod Johnson and Guillaume Laforge in both files.

https://claude.ai/code/session_011maxUxJQK1TrNsU72Wbrkj