### PR TITLE
Add Atmosphere to Agent Frameworks & Libraries

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -219,6 +219,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** A framework-agnostic Java library providing core annotations and APIs for implementing Model Context Protocol (MCP) servers and clients. Used by WildFly AI Feature Pack and LangChain4j-CDI. Compatible with OpenLiberty, Quarkus, and other Java frameworks.
 - **Links:** [GitHub](https://github.com/mcp-java/java-mcp-annotations)
 
+### Atmosphere
+- **Badge:** Framework
+- **Description:** A portable layer across Java AI runtimes. Write `@Agent` once against a unified API (tool calling, memory, streaming, structured output); swap the runtime — Spring AI, LangChain4j, Google ADK, Embabel, Koog, or built-in OpenAI — by changing one dependency. `@Coordinator` orchestrates multi-agent fleets with parallel, sequential, and conditional routing. Served over transports (WebTransport/HTTP3, WebSocket, SSE, long-polling, gRPC) and protocols (MCP, A2A, AG-UI). Built by Async-IO.
+- **Links:** [Docs](https://atmosphere.github.io/docs/) · [GitHub](https://github.com/Atmosphere/atmosphere) · [Async-IO](https://async-io.live)
+
 ---
 
 ## Java with Code Assistants

--- a/index.html
+++ b/index.html
@@ -612,6 +612,17 @@
         </div>
       </div>
 
+      <div class="card">
+        <span class="card-badge badge-framework">Framework</span>
+        <h3><a href="https://atmosphere.github.io/docs/">Atmosphere</a></h3>
+        <p>A portable layer across Java AI runtimes. Write <code>@Agent</code> once against a unified API (tool calling, memory, streaming, structured output); swap the runtime &mdash; Spring AI, LangChain4j, Google ADK, Embabel, Koog, or built-in OpenAI &mdash; by changing one dependency. <code>@Coordinator</code> orchestrates multi-agent fleets with parallel, sequential, and conditional routing. Served over transports (WebTransport/HTTP3, WebSocket, SSE, long-polling, gRPC) and protocols (MCP, A2A, AG-UI). Built by Async-IO.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://atmosphere.github.io/docs/" title="Docs"></a>
+          <a class="icon icon-github" href="https://github.com/Atmosphere/atmosphere" title="GitHub"></a>
+          <a class="icon icon-web" href="https://async-io.live" title="Async-IO"></a>
+        </div>
+      </div>
+
     </div>
   </div>
 </section>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-04-08</lastmod>
+    <lastmod>2026-04-10</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Adds [Atmosphere](https://github.com/Atmosphere/atmosphere) to the **Agent Frameworks & Libraries** section.

Atmosphere is a portable layer across Java AI runtimes. Write `@Agent` once against a unified API (tool calling, memory, streaming, structured output); swap the runtime — Spring AI, LangChain4j, Google ADK, Embabel, Koog, or a built-in OpenAI-compatible client — by changing one dependency. `@Coordinator` orchestrates multi-agent fleets with parallel, sequential, and conditional routing. Served over transports (WebTransport/HTTP3, WebSocket, SSE, long-polling, gRPC) and protocols (MCP, A2A, AG-UI).

## Activity check

- Active development, current release: [4.0.35](https://central.sonatype.com/artifact/org.atmosphere/atmosphere-runtime/4.0.35) (April 2026) on Maven Central
- Apache 2.0, maintained by Async-IO
- GitHub: https://github.com/Atmosphere/atmosphere
- Docs: https://atmosphere.github.io/docs/

## Files changed

- `SPEC.md` — new entry under "Agent Frameworks & Libraries"
- `index.html` — matching card at the end of the `#frameworks` section
- `sitemap.xml` — `lastmod` bumped to today

Rendered the card locally; icons, badge, and code formatting render consistently with sibling cards.