### PR TITLE
Add François Martin to people to follow

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -430,6 +430,14 @@ Notes:
 - **Role:** Creator of Jlama — Java LLM inference
 - **Links:** [@tjake](https://twitter.com/tjake) · [GitHub](https://github.com/tjake) · [LinkedIn](https://www.linkedin.com/in/tjake/)
 
+### François Martin
+
+- **Badge:** Person
+- **Initials:** FM
+- **Photo:** https://avatars.githubusercontent.com/u/14319020?v=4
+- **Role:** International speaker and author, Oracle ACE Associate, senior full-stack software engineer
+- **Links:** [@fmartin_](https://x.com/fmartin_) · [GitHub](https://github.com/martinfrancois) · [LinkedIn](https://www.linkedin.com/in/fran%c3%a7oismartin/) · [Bluesky](https://bsky.app/profile/fmartin.ch) · [YouTube](https://www.youtube.com/@fmartindev) · [Website](https://fmartin.ch)
+
 ### Simon Martinelli
 
 - **Badge:** Person

--- a/index.html
+++ b/index.html
@@ -985,6 +985,22 @@
       </div>
 
       <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/14319020?v=4" alt="François Martin"></div>
+        <div class="person-info">
+          <h4>François Martin</h4>
+          <p>International speaker and author, Oracle ACE Associate, senior full-stack software engineer</p>
+          <div class="person-links">
+            <a class="icon icon-x" href="https://x.com/fmartin_" title="@fmartin_"></a>
+            <a class="icon icon-github" href="https://github.com/martinfrancois" title="GitHub"></a>
+            <a class="icon icon-linkedin" href="https://www.linkedin.com/in/fran%c3%a7oismartin/" title="LinkedIn"></a>
+            <a class="icon icon-bluesky" href="https://bsky.app/profile/fmartin.ch" title="Bluesky"></a>
+            <a class="icon icon-youtube" href="https://www.youtube.com/@fmartindev" title="YouTube"></a>
+            <a class="icon icon-web" href="https://fmartin.ch" title="Website"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/593352?v=4" alt="Simon Martinelli"></div>
         <div class="person-info">
           <h4>Simon Martinelli</h4>


### PR DESCRIPTION
## Summary

- Add François Martin to the People to Follow section in `SPEC.md`
- Regenerate `index.html` to include the matching person card
- Include available profile links for X/Twitter, GitHub, LinkedIn, Bluesky, YouTube, and website

## Validation

- Served the static site locally and verified the new card rendered under `#people`
