### PR TITLE
Add ClawRunr Java AI agent runtime

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -250,6 +250,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** DataStax's pure-Java embedded vector search engine combining DiskANN and HNSW graph designs for approximate nearest-neighbor search, SIMD-accelerated via the Java Vector API. Supports indexes larger than available memory via two-pass compressed search. Powers Apache Cassandra and AstraDB; has an official LangChain4j embedding-store integration.
 - **Links:** [GitHub](https://github.com/datastax/jvector) · [LangChain4j Integration](https://docs.langchain4j.dev/integrations/embedding-stores/jvector/)
 
+### ClawRunr
+- **Badge:** Framework
+- **Description:** Open-source personal AI agent runtime built on Spring Boot, Spring AI, and JobRunr — runs entirely on your own hardware. Schedules and executes background tasks, browses the web, and manages work via human-readable Markdown files, with multi-channel support (chat UI, Telegram, Discord) and pluggable OpenAI, Anthropic, or Ollama providers. Built by the JobRunr team; started as a demo and grew into a community project.
+- **Links:** [GitHub](https://github.com/ClawRunr/JavaClaw) · [Website](https://clawrunr.io/)
+
 ---
 
 ## Java with Code Assistants

--- a/index.html
+++ b/index.html
@@ -81,7 +81,8 @@
       {"@type": "ListItem", "position": 24, "name": "Spring AI Agent Utils", "url": "https://springaicommunity.mintlify.app/projects/incubating/spring-ai-agent-utils"},
       {"@type": "ListItem", "position": 25, "name": "Jakarta Agentic AI", "url": "https://github.com/jakartaee/agentic-ai"},
       {"@type": "ListItem", "position": 26, "name": "AgentScope Java", "url": "https://java.agentscope.io/"},
-      {"@type": "ListItem", "position": 27, "name": "JVector", "url": "https://github.com/datastax/jvector"}
+      {"@type": "ListItem", "position": 27, "name": "JVector", "url": "https://github.com/datastax/jvector"},
+      {"@type": "ListItem", "position": 28, "name": "ClawRunr", "url": "https://github.com/ClawRunr/JavaClaw"}
     ]
   }
   </script>
@@ -690,6 +691,16 @@
         <div class="card-links">
           <a class="icon icon-github" href="https://github.com/datastax/jvector" title="GitHub"></a>
           <a class="icon icon-web" href="https://docs.langchain4j.dev/integrations/embedding-stores/jvector/" title="LangChain4j Integration"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-framework">Framework</span>
+        <h3><a href="https://github.com/ClawRunr/JavaClaw">ClawRunr</a></h3>
+        <p>Open-source personal AI agent runtime built on Spring Boot, Spring AI, and JobRunr &mdash; runs entirely on your own hardware. Schedules and executes background tasks, browses the web, and manages work via human-readable Markdown files, with multi-channel support (chat UI, Telegram, Discord) and pluggable OpenAI, Anthropic, or Ollama providers. Built by the JobRunr team; started as a demo and grew into a community project.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/ClawRunr/JavaClaw" title="GitHub"></a>
+          <a class="icon icon-web" href="https://clawrunr.io/" title="Website"></a>
         </div>
       </div>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-07-17</lastmod>
+    <lastmod>2026-07-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Adds **ClawRunr** (formerly JavaClaw) to the Agent Frameworks & Libraries section — a community-driven, actively maintained personal AI agent runtime from the JobRunr team, built on Spring Boot, Spring AI, and JobRunr (LGPL-3.0, ~700 GitHub stars). It was missing from the site despite being a notable, actively developed Java-native agent project ([GitHub](https://github.com/ClawRunr/JavaClaw), [Website](https://clawrunr.io/)).
- Reviewed the existing News section against today's date (2026-07-18) — all current items are still within the 3-month freshness window, so no removals were needed.
- Updated `sitemap.xml` `<lastmod>` to reflect the content change.

## Test plan
- [x] Verified `SPEC.md` and `index.html` stay in sync (card, badge, links, and `ItemList` JSON-LD entry added consistently)
- [x] Verified all links (GitHub repo, website) resolve and match the description
- [x] Confirmed no existing news items have aged past the 3-month cutoff

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TWoGhQs3K86UxAVv4mcD4Q

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWoGhQs3K86UxAVv4mcD4Q)_