### PR TITLE
Add EclipseStore embedded Java vector database

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -272,6 +272,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** Pure-Java agentic framework that converts natural-language prompts into executable actions — Java method calls, REST endpoints, shell commands, or Swagger API calls — with multi-provider support across Gemini, OpenAI, Anthropic, and LocalAI. No Spring dependency required. MIT licensed, published to Maven Central.
 - **Links:** [GitHub](https://github.com/vishalmysore/Tools4AI) · [Javadoc](https://javadoc.io/doc/io.github.vishalmysore/tools4ai/latest/index.html)
 
+### EclipseStore
+- **Badge:** Library
+- **Description:** Eclipse Foundation's Java-native persistence engine — stores and loads full object graphs with microsecond response times, no JPA/ORM overhead. Version 4 integrates JVector into its GigaMap indexing, turning EclipseStore into an embedded, pure-Java vector database: HNSW similarity search, on-disk indexing for datasets larger than memory, and Product Quantization to shrink embedding footprints by up to 90%.
+- **Links:** [GitHub](https://github.com/eclipse-store/store) · [Docs](https://docs.eclipsestore.io/manual/gigamap/index.html) · [Blog](https://microstream.one/blog/2026/02/13/eclipsestore-4-beta-build-vector-database-apps-with-pure-java/)
+
 ---
 
 ## Java with Code Assistants

--- a/index.html
+++ b/index.html
@@ -88,7 +88,8 @@
       {"@type": "ListItem", "position": 31, "name": "JVector", "url": "https://github.com/datastax/jvector"},
       {"@type": "ListItem", "position": 32, "name": "ClawRunr", "url": "https://github.com/ClawRunr/JavaClaw"},
       {"@type": "ListItem", "position": 33, "name": "MCP Toolbox Java SDK", "url": "https://github.com/googleapis/mcp-toolbox-sdk-java"},
-      {"@type": "ListItem", "position": 34, "name": "Tools4AI", "url": "https://github.com/vishalmysore/Tools4AI"}
+      {"@type": "ListItem", "position": 34, "name": "Tools4AI", "url": "https://github.com/vishalmysore/Tools4AI"},
+      {"@type": "ListItem", "position": 35, "name": "EclipseStore", "url": "https://github.com/eclipse-store/store"}
     ]
   }
   </script>
@@ -739,6 +740,17 @@
         <div class="card-links">
           <a class="icon icon-github" href="https://github.com/vishalmysore/Tools4AI" title="GitHub"></a>
           <a class="icon icon-web" href="https://javadoc.io/doc/io.github.vishalmysore/tools4ai/latest/index.html" title="Javadoc"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-inference">Library</span>
+        <h3><a href="https://github.com/eclipse-store/store">EclipseStore</a></h3>
+        <p>Eclipse Foundation's Java-native persistence engine &mdash; stores and loads full object graphs with microsecond response times, no JPA/ORM overhead. Version 4 integrates JVector into its GigaMap indexing, turning EclipseStore into an embedded, pure-Java vector database: HNSW similarity search, on-disk indexing for datasets larger than memory, and Product Quantization to shrink embedding footprints by up to 90%.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/eclipse-store/store" title="GitHub"></a>
+          <a class="icon icon-web" href="https://docs.eclipsestore.io/manual/gigamap/index.html" title="Docs"></a>
+          <a class="icon icon-web" href="https://microstream.one/blog/2026/02/13/eclipsestore-4-beta-build-vector-database-apps-with-pure-java/" title="Blog"></a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- Add **EclipseStore** to Agent Frameworks & Libraries (`SPEC.md` + `index.html` card + `ItemList` JSON-LD entry)
- Eclipse Foundation's Java-native persistence engine — version 4 integrates JVector into its GigaMap indexing, turning it into an embedded, pure-Java vector database (HNSW search, on-disk indexing for larger-than-memory datasets, Product Quantization compression). Complements the existing standalone JVector entry.
- Verified via [GitHub](https://github.com/eclipse-store/store), [docs](https://docs.eclipsestore.io/manual/gigamap/index.html), and the [MicroStream announcement blog](https://microstream.one/blog/2026/02/13/eclipsestore-4-beta-build-vector-database-apps-with-pure-java/); latest release v4.1.0 (May 2026), actively maintained.
- Bumped `sitemap.xml` `<lastmod>` to match.

## Research notes
Did a broad sweep of the Java/JVM AI ecosystem (news, frameworks, MCP servers, inference/training libs, people) against the site's `CONTRIBUTING.md` governance policy (Java-specific, >10% relevance, actively maintained). Most of the ecosystem is already well covered by the site — EclipseStore was the one clear, well-verified gap. A couple of lower-confidence candidates (e.g. `inference4j`, a thin ONNX wrapper with ~45 stars) were considered but skipped as not clearly meeting the bar. No stale/abandoned entries or outdated news items were found.

## Test plan
- [x] Followed `AGENTS.md` process: updated `SPEC.md` first, then `index.html` to match
- [x] Verified all new links resolve and content was fetched (not guessed) from live sources
- [x] Checked card markup/badge classes against existing similarly-badged entries (e.g. JVector) for visual consistency

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9TaGBLbu3nfFiNU2MGfCb

---
_Generated by [Claude Code](https://claude.ai/code/session_01X9TaGBLbu3nfFiNU2MGfCb)_