### PR TITLE
Add Micronaut MCP, remove stale MCP RCE news item

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -94,7 +94,6 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/
 - https://blog.ovhcloud.com/devoxx-france-2026/
 - https://quarkus.io/blog/introducing-agent-mcp/
-- https://thehackernews.com/2026/04/anthropic-mcp-design-vulnerability.html
 
 ---
 
@@ -134,6 +133,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Badge:** Framework
 - **Description:** Helidon's Model Context Protocol server and client implementation. Declarative and imperative APIs for building MCP servers with tools, resources, and prompts. Streamable HTTP and SSE transports, virtual threads, build-time processing. From Oracle's Helidon team.
 - **Links:** [Docs](https://helidon.io/docs/v4/se/ai/mcp) · [GitHub](https://github.com/helidon-io/helidon-mcp)
+
+### Micronaut MCP
+- **Badge:** Framework
+- **Description:** Official Micronaut module for building Model Context Protocol servers and clients. STDIO and Streamable HTTP transports, annotation and factory-based tools/prompts/resources, a LangChain4j-backed client option, and GraalVM native image support. Maintained by the Micronaut project team.
+- **Links:** [Docs](https://micronaut-projects.github.io/micronaut-mcp/latest/guide/) · [GitHub](https://github.com/micronaut-projects/micronaut-mcp)
 
 ### LangChain4j-CDI
 - **Badge:** Framework

--- a/index.html
+++ b/index.html
@@ -82,7 +82,8 @@
       {"@type": "ListItem", "position": 25, "name": "Jakarta Agentic AI", "url": "https://github.com/jakartaee/agentic-ai"},
       {"@type": "ListItem", "position": 26, "name": "AgentScope Java", "url": "https://java.agentscope.io/"},
       {"@type": "ListItem", "position": 27, "name": "JVector", "url": "https://github.com/datastax/jvector"},
-      {"@type": "ListItem", "position": 28, "name": "ClawRunr", "url": "https://github.com/ClawRunr/JavaClaw"}
+      {"@type": "ListItem", "position": 28, "name": "ClawRunr", "url": "https://github.com/ClawRunr/JavaClaw"},
+      {"@type": "ListItem", "position": 29, "name": "Micronaut MCP", "url": "https://github.com/micronaut-projects/micronaut-mcp"}
     ]
   }
   </script>
@@ -381,7 +382,6 @@
         <li><a href="https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/">Koog 1.0 Is Out</a> &mdash; JetBrains' Kotlin/Java agent framework reaches a stable core with a 1-year API guarantee, a redesigned Java interop layer, decoupled HTTP transport, and OpenTelemetry observability</li>
         <li><a href="https://blog.ovhcloud.com/devoxx-france-2026/">Devoxx France 2026: OVHcloud Highlights and Key Trends</a> &mdash; 65 of 259 sessions covered AI and agentic systems, the most-discussed topic, with a shift from experimentation toward production, RAG, observability, and governance</li>
         <li><a href="https://quarkus.io/blog/introducing-agent-mcp/">Introducing Quarkus Agent MCP: Teaching AI Agents to Speak Quarkus</a> &mdash; a standalone MCP server that scaffolds and manages Quarkus apps, survives crashes, and searches Quarkus docs for Claude Code, Copilot, Cursor, and JetBrains AI</li>
-        <li><a href="https://thehackernews.com/2026/04/anthropic-mcp-design-vulnerability.html">MCP's "By Design" STDIO Flaw Enables RCE Across the Ecosystem</a> &mdash; researchers disclosed a systemic command-injection weakness in MCP's STDIO transport affecting official SDKs in every supported language, including Java; Anthropic confirmed the execution model is intentional</li>
       </ul>
     </div>
   </div>
@@ -463,6 +463,16 @@
         <div class="card-links">
           <a class="icon icon-web" href="https://helidon.io/docs/v4/se/ai/mcp" title="Docs"></a>
           <a class="icon icon-github" href="https://github.com/helidon-io/helidon-mcp" title="GitHub"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-framework">Framework</span>
+        <h3><a href="https://micronaut-projects.github.io/micronaut-mcp/latest/guide/">Micronaut MCP</a></h3>
+        <p>Official Micronaut module for building Model Context Protocol servers and clients. STDIO and Streamable HTTP transports, annotation and factory-based tools/prompts/resources, a LangChain4j-backed client option, and GraalVM native image support. Maintained by the Micronaut project team.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://micronaut-projects.github.io/micronaut-mcp/latest/guide/" title="Docs"></a>
+          <a class="icon icon-github" href="https://github.com/micronaut-projects/micronaut-mcp" title="GitHub"></a>
         </div>
       </div>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-07-18</lastmod>
+    <lastmod>2026-07-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Add **Micronaut MCP** to Agent Frameworks & Libraries — the official Micronaut module for building MCP servers/clients (STDIO + Streamable HTTP transports, LangChain4j-backed client option, GraalVM native support), analogous to the existing Helidon MCP entry. Verified via the project's GitHub repo and docs (v1.1.0, released 2026-06-18, actively maintained by the Micronaut Projects team).
- Remove the thehackernews.com "MCP STDIO RCE" news item — confirmed published 2026-04-20, which has now aged out of the site's 3-month news window (today is 2026-07-20).
- Updated `SPEC.md` (source of truth) first, then `index.html` (card + JSON-LD ItemList entry) to match, and bumped `sitemap.xml`'s `<lastmod>`.

Researched per `CONTRIBUTING.md`/`SPEC.md` guidelines (Java-specific, active-maintenance, >10% relevance bar) — no other significant gaps or activity concerns found since the site's last update on 2026-07-18.

## Test plan
- [x] Validated `index.html` parses without errors (`html.parser`)
- [x] Verified card-count consistency in the diff
- [x] Fetched live pages to confirm Micronaut MCP repo/docs details and the news article's exact publish date

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_013k3ggv1igMz5J4K7UzY2RL)_