### PR TITLE
Add missing SDKs, MCP servers, news, and resources

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -86,16 +86,20 @@ Questions and answers:
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
-- https://akka.io/blog/announcing-akkas-agentic-ai-release
-- https://foojay.io/today/i-asked-github-copilot-to-profile-a-java-app-it-found-a-bug-in-my-heap-sizing-and-offered-to-fix-it/
+- https://github.com/beehive-lab/TornadoVM/releases/tag/v5.1.0-jdk21
 - https://github.com/langchain4j/langchain4j/releases/tag/1.18.0
+- https://foojay.io/today/i-asked-github-copilot-to-profile-a-java-app-it-found-a-bug-in-my-heap-sizing-and-offered-to-fix-it/
 - https://quarkus.io/blog/quarkus-langchain4j-opa-guardrails/
 - https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.0.0
 - https://javapro.io/2026/07/08/langchain4j-agentic-workflows-from-ai-calls-to-multi-agent-systems-in-java/
 - https://spring.io/blog/2026/06/12/spring-ai-2-0-0-GA-available-now
-- https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/
 - https://java.agentscope.io/v2/en/blogs/agentscope-v2-release.html
+- https://javapro.io/2026/06/03/the-gen-ai-iceberg-java-tooling-edition/
+- https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/
+- https://quarkus.io/blog/introducing-voting-pattern/
+- https://micronaut.io/2026/05/20/micronaut-framework-5-0-0-released/
 - https://blog.ovhcloud.com/devoxx-france-2026/
+- https://quarkus.io/blog/a2a-java-sdk-1-0-0-cr1-released/
 - https://quarkus.io/blog/introducing-agent-mcp/
 
 ---
@@ -277,6 +281,26 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** Eclipse Foundation's Java-native persistence engine — stores and loads full object graphs with microsecond response times, no JPA/ORM overhead. Version 4 integrates JVector into its GigaMap indexing, turning EclipseStore into an embedded, pure-Java vector database: HNSW similarity search, on-disk indexing for datasets larger than memory, and Product Quantization to shrink embedding footprints by up to 90%.
 - **Links:** [GitHub](https://github.com/eclipse-store/store) · [Docs](https://docs.eclipsestore.io/manual/gigamap/index.html) · [Blog](https://microstream.one/blog/2026/02/13/eclipsestore-4-beta-build-vector-database-apps-with-pure-java/)
 
+### OpenAI Java SDK
+- **Badge:** SDK
+- **Description:** Official Java client library for the OpenAI API, maintained by OpenAI. Written in Kotlin with full Java interop. Typed access to Chat Completions and the Responses API, streaming, structured outputs, function calling, and asynchronous execution via `CompletableFuture`.
+- **Links:** [GitHub](https://github.com/openai/openai-java)
+
+### Google Gen AI Java SDK
+- **Badge:** SDK
+- **Description:** Google's official Java SDK unifying access to the Gemini Developer API and Vertex AI. Supports Gemini text/chat, Imagen image generation, Veo video generation, embeddings, token counting, and automatic function calling, with streaming and async options. Distinct from Google ADK for Java, which is an agent-orchestration framework built on top of it.
+- **Links:** [GitHub](https://github.com/googleapis/java-genai) · [Docs](https://googleapis.github.io/java-genai/javadoc/)
+
+### IBM watsonx.ai Java SDK
+- **Badge:** SDK
+- **Description:** IBM's official Java SDK for the watsonx.ai enterprise AI platform. Chat completions, streaming, tool calling, embeddings, text classification/extraction/detection, reranking, and time-series forecasting, for both IBM Cloud and on-premises (CP4D) deployments. Integrates with LangChain4j, Quarkus, and Apache Camel.
+- **Links:** [GitHub](https://github.com/IBM/watsonx-ai-java-sdk) · [Docs](https://ibm.github.io/watsonx-ai-java-sdk/)
+
+### SAP AI SDK for Java
+- **Badge:** SDK
+- **Description:** SAP's official Java SDK for integrating generative AI into enterprise applications via SAP AI Core and the Generative AI Hub. Orchestration service integration, prompt templating, grounding, data masking, content filtering, and Spring AI compatibility.
+- **Links:** [GitHub](https://github.com/SAP/ai-sdk-java)
+
 ---
 
 ## Java with Code Assistants
@@ -344,6 +368,26 @@ Technologies that supercharge Java development when paired with AI code assistan
 - **Badge:** MCP Server
 - **Description:** IntelliJ IDEA's built-in Model Context Protocol server, bundled and enabled by default since version 2025.2. Exposes over 100 IDE tools — code analysis, refactoring, debugging, run configurations, database operations — to external MCP clients like Claude Code, Claude Desktop, Cursor, and VS Code. Distinct from the JetBrains AI Assistant plugin above.
 - **Links:** [Docs](https://www.jetbrains.com/help/idea/mcp-server.html)
+
+### Apache Camel MCP Server
+- **Badge:** MCP Server
+- **Description:** Official MCP server shipped with Apache Camel 4.18 (`camel-jbang-mcp`). Exposes the live Camel and Kamelet catalogs, endpoint-URI validation, route understanding, and security analysis as 16 tools for AI coding assistants. Built on Quarkus, runs via JBang, supports STDIO and HTTP/SSE transports.
+- **Links:** [Blog](https://camel.apache.org/blog/2026/02/camel-jbang-mcp/) · [Manual](https://camel.apache.org/manual/camel-jbang-mcp.html)
+
+### Micronaut Fun MCP Server
+- **Badge:** MCP Server
+- **Description:** Official MCP server from the Micronaut project team giving AI assistants search access to Micronaut documentation and Guides via OpenSearch. Confirmed integrations for Claude Code, Claude Desktop, VS Code, cline, and IntelliJ IDEA.
+- **Links:** [Website](https://micronaut.fun/) · [GitHub](https://github.com/micronaut-projects/micronaut-fun)
+
+### Develocity MCP Servers
+- **Badge:** MCP Server
+- **Description:** Two official MCP servers from Gradle Inc.'s Develocity platform — one for per-build data (exceptions, stack traces, test outcomes, cache performance) to investigate failures, and an Analytics server for org-wide queries like flaky-test trends and cache effectiveness. Covers Gradle, Maven, sbt, and Bazel builds.
+- **Links:** [Docs](https://docs.develocity.ai/2026.1/integrations/mcp-servers/)
+
+### AssistAI (Eclipse IDE MCP Server)
+- **Badge:** Extension
+- **Description:** Community Eclipse IDE plugin (formerly "eclipse-chatgpt-plugin") that exposes the Eclipse workspace as an MCP server — code analysis, refactoring, build/debug control, and Git operations via EGit — so external AI agents like Claude Code edit through Eclipse's JDT APIs instead of the raw filesystem, keeping incremental compilation and error highlighting in sync. Also bundles an inline AI chat view. MIT licensed.
+- **Links:** [Eclipse Marketplace](https://marketplace.eclipse.org/content/assistai-eclipse-ide-mcp-server-ai-agents) · [GitHub](https://github.com/gradusnikov/eclipse-chatgpt-plugin)
 
 ---
 
@@ -741,6 +785,24 @@ Yes. Most Java AI frameworks run on any JVM language. Embabel is written in Kotl
 - **Badge:** Livestream
 - **Description:** James Ward and Julian Wood explore building AI-powered Java apps — MCP integration, agent architectures with AgentCore, GraalVM optimization for AI workloads, and secure auth patterns for AI services on serverless
 - **Links:** https://www.youtube.com/watch?v=my2bQtHBUeY
+
+### Java for an AI World — JavaOne 2026 Opening Keynote
+
+- **Badge:** Videos
+- **Description:** Opening keynote of JavaOne 2026, featuring Rod Johnson, Josh Long, and engineering leads from Oracle, Microsoft, NVIDIA, JetBrains, and Uber on Java's AI direction, including the GitHub Copilot SDK for Java
+- **Links:** https://www.youtube.com/watch?v=3fLCOqpIfI0
+
+### Bootiful Spring AI — Josh Long & James Ward @ Spring I/O 2026
+
+- **Badge:** Videos
+- **Description:** Talk from Spring I/O 2026 in Barcelona demystifying AI integration with Spring Boot — agentic patterns, Spring AI, and MCP integration
+- **Links:** https://www.youtube.com/watch?v=nHnKReitDXc
+
+### Liberty LangChain4j Workshop
+
+- **Badge:** Workshop
+- **Description:** Hands-on, self-paced Open Liberty workshop that progresses from a simple chatbot to agentic systems using LangChain4j — prompt engineering, streaming, RAG, tool calling, MCP, guardrails/observability, and multi-agent supervisor patterns
+- **Links:** [Workshop](https://openliberty.github.io/liberty-workshop-langchain4j/) · [Blog](https://openliberty.io/blog/2026/07/10/liberty-langchain4j-workshop.html)
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -89,7 +89,11 @@
       {"@type": "ListItem", "position": 32, "name": "ClawRunr", "url": "https://github.com/ClawRunr/JavaClaw"},
       {"@type": "ListItem", "position": 33, "name": "MCP Toolbox Java SDK", "url": "https://github.com/googleapis/mcp-toolbox-sdk-java"},
       {"@type": "ListItem", "position": 34, "name": "Tools4AI", "url": "https://github.com/vishalmysore/Tools4AI"},
-      {"@type": "ListItem", "position": 35, "name": "EclipseStore", "url": "https://github.com/eclipse-store/store"}
+      {"@type": "ListItem", "position": 35, "name": "EclipseStore", "url": "https://github.com/eclipse-store/store"},
+      {"@type": "ListItem", "position": 36, "name": "OpenAI Java SDK", "url": "https://github.com/openai/openai-java"},
+      {"@type": "ListItem", "position": 37, "name": "Google Gen AI Java SDK", "url": "https://github.com/googleapis/java-genai"},
+      {"@type": "ListItem", "position": 38, "name": "IBM watsonx.ai Java SDK", "url": "https://github.com/IBM/watsonx-ai-java-sdk"},
+      {"@type": "ListItem", "position": 39, "name": "SAP AI SDK for Java", "url": "https://github.com/SAP/ai-sdk-java"}
     ]
   }
   </script>
@@ -380,16 +384,20 @@
     <div class="news-bar">
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Headlines</h2>
       <ul>
-        <li><a href="https://akka.io/blog/announcing-akkas-agentic-ai-release">Akka Agentic Platform Announced</a> &mdash; four integrated offerings (Akka Orchestration, Akka Agents, Akka Memory, Akka Streaming) for building durable, crash-resilient multi-agent systems, with Java and Scala SDKs</li>
-        <li><a href="https://foojay.io/today/i-asked-github-copilot-to-profile-a-java-app-it-found-a-bug-in-my-heap-sizing-and-offered-to-fix-it/">JVM Pulse: Profiling Java with GitHub Copilot</a> &mdash; new open-source Copilot canvas extension from Bruno Borges automates GC/JFR profiling and hands off findings to Copilot for AI-driven tuning recommendations</li>
+        <li><a href="https://github.com/beehive-lab/TornadoVM/releases/tag/v5.1.0-jdk21">TornadoVM 5.1.0 Adds FP8 GPU Support</a> &mdash; the Java-to-GPU compiler gains FP8 (E4M3/E5M2) precision for CUDA, a CUTLASS hybrid-API provider for fused GEMM operations, and Windows CUDA support, advancing GPU-accelerated inference for GPULlama3.java and LangChain4j</li>
         <li><a href="https://github.com/langchain4j/langchain4j/releases/tag/1.18.0">LangChain4j 1.18.0 Released</a> &mdash; introduces a Belief-Desire-Intention (BDI) agentic pattern, crash-resilient Human-in-the-Loop suspend/resume for agentic systems, OpenAI TTS support, and a revamped embedding-model API with per-call parameters and multimodal input</li>
+        <li><a href="https://foojay.io/today/i-asked-github-copilot-to-profile-a-java-app-it-found-a-bug-in-my-heap-sizing-and-offered-to-fix-it/">JVM Pulse: Profiling Java with GitHub Copilot</a> &mdash; new open-source Copilot canvas extension from Bruno Borges automates GC/JFR profiling and hands off findings to Copilot for AI-driven tuning recommendations</li>
         <li><a href="https://quarkus.io/blog/quarkus-langchain4j-opa-guardrails/">Compiling OPA Policies to WebAssembly for Quarkus LangChain4j Guardrails</a> &mdash; sub-millisecond prompt-injection pattern matching via Open Policy Agent rules compiled to Wasm, falling back to an LLM only for inconclusive cases</li>
         <li><a href="https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.0.0">Spring AI AgentCore SDK v2.0.0 Released</a> &mdash; major version release of the open-source Spring Boot integration for Amazon Bedrock AgentCore, with auto-configured invocation endpoints, SSE streaming, and short/long-term memory support</li>
         <li><a href="https://javapro.io/2026/07/08/langchain4j-agentic-workflows-from-ai-calls-to-multi-agent-systems-in-java/">LangChain4j Agentic Workflows: From AI Calls to Multi-Agent Systems</a> &mdash; tutorial covering sequential, loop, parallel, and conditional workflow patterns, goal-oriented planning, and supervisor-based multi-agent systems in Java</li>
         <li><a href="https://spring.io/blog/2026/06/12/spring-ai-2-0-0-GA-available-now">Spring AI 2.0.0 GA Available Now</a> &mdash; built on Spring Boot 4 with Jackson 3 JSON handling and null-safety annotations, tool calling elevated to a composable advisor-chain component for agentic patterns, and Model Context Protocol integration with annotation-driven programming and enterprise security</li>
-        <li><a href="https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/">Koog 1.0 Is Out</a> &mdash; JetBrains' Kotlin/Java agent framework reaches a stable core with a 1-year API guarantee, a redesigned Java interop layer, decoupled HTTP transport, and OpenTelemetry observability</li>
         <li><a href="https://java.agentscope.io/v2/en/blogs/agentscope-v2-release.html">AgentScope Java v2.0.0 GA</a> &mdash; Alibaba's JVM-native agent framework reaches production-ready GA, with event-streaming, permission-gated tool execution, and a Workspace abstraction for long-running, safely sandboxed agents</li>
+        <li><a href="https://javapro.io/2026/06/03/the-gen-ai-iceberg-java-tooling-edition/">The Gen AI Iceberg: Java Tooling Edition</a> &mdash; a tiered tour of Java's generative AI tooling, from mainstream frameworks like Spring AI and LangChain4j down to GPU kernel compilation and Project Babylon, arguing the JVM runs AI workloads natively rather than just calling out to them</li>
+        <li><a href="https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/">Koog 1.0 Is Out</a> &mdash; JetBrains' Kotlin/Java agent framework reaches a stable core with a 1-year API guarantee, a redesigned Java interop layer, decoupled HTTP transport, and OpenTelemetry observability</li>
+        <li><a href="https://quarkus.io/blog/introducing-voting-pattern/">Parallel Voting and Adaptive Model Selection in Quarkus</a> &mdash; LangChain4j's new voting pattern dispatches tasks to multiple evaluator agents in parallel and aggregates results, paired with dynamic chat model switching to balance cost and quality in agentic workflows</li>
+        <li><a href="https://micronaut.io/2026/05/20/micronaut-framework-5-0-0-released/">Micronaut Framework 5.0.0 Released</a> &mdash; major platform refresh across 70+ modules adds a new Micronaut MCP module built on the MCP Java SDK, plus updated Micronaut LangChain4j integration, alongside Java 25/Kotlin 2.3 baselines</li>
         <li><a href="https://blog.ovhcloud.com/devoxx-france-2026/">Devoxx France 2026: OVHcloud Highlights and Key Trends</a> &mdash; 65 of 259 sessions covered AI and agentic systems, the most-discussed topic, with a shift from experimentation toward production, RAG, observability, and governance</li>
+        <li><a href="https://quarkus.io/blog/a2a-java-sdk-1-0-0-cr1-released/">A2A Java SDK 1.0.0.CR1 Released</a> &mdash; candidate release of the Agent2Agent Java SDK adds a v0.3 protocol compatibility layer, an Android HTTP client, and improved SSE parsing ahead of GA</li>
         <li><a href="https://quarkus.io/blog/introducing-agent-mcp/">Introducing Quarkus Agent MCP: Teaching AI Agents to Speak Quarkus</a> &mdash; a standalone MCP server that scaffolds and manages Quarkus apps, survives crashes, and searches Quarkus docs for Claude Code, Copilot, Cursor, and JetBrains AI</li>
       </ul>
     </div>
@@ -754,6 +762,44 @@
         </div>
       </div>
 
+      <div class="card">
+        <span class="card-badge badge-inference">SDK</span>
+        <h3><a href="https://github.com/openai/openai-java">OpenAI Java SDK</a></h3>
+        <p>Official Java client library for the OpenAI API, maintained by OpenAI. Written in Kotlin with full Java interop. Typed access to Chat Completions and the Responses API, streaming, structured outputs, function calling, and asynchronous execution via <code>CompletableFuture</code>.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/openai/openai-java" title="GitHub"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-inference">SDK</span>
+        <h3><a href="https://github.com/googleapis/java-genai">Google Gen AI Java SDK</a></h3>
+        <p>Google's official Java SDK unifying access to the Gemini Developer API and Vertex AI. Supports Gemini text/chat, Imagen image generation, Veo video generation, embeddings, token counting, and automatic function calling. Distinct from Google ADK for Java, which is an agent-orchestration framework built on top of it.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/googleapis/java-genai" title="GitHub"></a>
+          <a class="icon icon-web" href="https://googleapis.github.io/java-genai/javadoc/" title="Docs"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-inference">SDK</span>
+        <h3><a href="https://github.com/IBM/watsonx-ai-java-sdk">IBM watsonx.ai Java SDK</a></h3>
+        <p>IBM's official Java SDK for the watsonx.ai enterprise AI platform. Chat completions, streaming, tool calling, embeddings, text classification/extraction/detection, reranking, and time-series forecasting, for both IBM Cloud and on-premises deployments. Integrates with LangChain4j, Quarkus, and Apache Camel.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/IBM/watsonx-ai-java-sdk" title="GitHub"></a>
+          <a class="icon icon-web" href="https://ibm.github.io/watsonx-ai-java-sdk/" title="Docs"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-inference">SDK</span>
+        <h3><a href="https://github.com/SAP/ai-sdk-java">SAP AI SDK for Java</a></h3>
+        <p>SAP's official Java SDK for integrating generative AI into enterprise applications via SAP AI Core and the Generative AI Hub. Orchestration service integration, prompt templating, grounding, data masking, content filtering, and Spring AI compatibility.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/SAP/ai-sdk-java" title="GitHub"></a>
+        </div>
+      </div>
+
     </div>
   </div>
 </section>
@@ -859,6 +905,42 @@
         <h3>IntelliJ IDEA MCP Server</h3>
         <p>IntelliJ IDEA's built-in Model Context Protocol server, bundled and enabled by default since version 2025.2. Exposes over 100 IDE tools &mdash; code analysis, refactoring, debugging, run configurations, database operations &mdash; to external MCP clients like Claude Code, Claude Desktop, Cursor, and VS Code. Distinct from the JetBrains AI Assistant plugin above.</p>
       </a>
+
+      <div class="card">
+        <span class="card-badge badge-assistant">MCP Server</span>
+        <h3><a href="https://camel.apache.org/blog/2026/02/camel-jbang-mcp/">Apache Camel MCP Server</a></h3>
+        <p>Official MCP server shipped with Apache Camel 4.18 (<code>camel-jbang-mcp</code>). Exposes the live Camel and Kamelet catalogs, endpoint-URI validation, route understanding, and security analysis as 16 tools for AI coding assistants. Built on Quarkus, runs via JBang, supports STDIO and HTTP/SSE transports.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://camel.apache.org/blog/2026/02/camel-jbang-mcp/" title="Blog"></a>
+          <a class="icon icon-web" href="https://camel.apache.org/manual/camel-jbang-mcp.html" title="Manual"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-assistant">MCP Server</span>
+        <h3><a href="https://micronaut.fun/">Micronaut Fun MCP Server</a></h3>
+        <p>Official MCP server from the Micronaut project team giving AI assistants search access to Micronaut documentation and Guides via OpenSearch. Confirmed integrations for Claude Code, Claude Desktop, VS Code, cline, and IntelliJ IDEA.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://micronaut.fun/" title="Website"></a>
+          <a class="icon icon-github" href="https://github.com/micronaut-projects/micronaut-fun" title="GitHub"></a>
+        </div>
+      </div>
+
+      <a class="card" href="https://docs.develocity.ai/2026.1/integrations/mcp-servers/">
+        <span class="card-badge badge-assistant">MCP Server</span>
+        <h3>Develocity MCP Servers</h3>
+        <p>Two official MCP servers from Gradle Inc.'s Develocity platform &mdash; one for per-build data (exceptions, stack traces, test outcomes, cache performance) to investigate failures, and an Analytics server for org-wide queries like flaky-test trends and cache effectiveness. Covers Gradle, Maven, sbt, and Bazel builds.</p>
+      </a>
+
+      <div class="card">
+        <span class="card-badge badge-assistant">Extension</span>
+        <h3><a href="https://marketplace.eclipse.org/content/assistai-eclipse-ide-mcp-server-ai-agents">AssistAI (Eclipse IDE MCP Server)</a></h3>
+        <p>Community Eclipse IDE plugin that exposes the Eclipse workspace as an MCP server &mdash; code analysis, refactoring, build/debug control, and Git operations via EGit &mdash; so external AI agents edit through Eclipse's JDT APIs instead of the raw filesystem, keeping incremental compilation and error highlighting in sync. Also bundles an inline AI chat view. MIT licensed.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://marketplace.eclipse.org/content/assistai-eclipse-ide-mcp-server-ai-agents" title="Eclipse Marketplace"></a>
+          <a class="icon icon-github" href="https://github.com/gradusnikov/eclipse-chatgpt-plugin" title="GitHub"></a>
+        </div>
+      </div>
 
     </div>
   </div>
@@ -1487,6 +1569,28 @@
         <h3>AI &amp; Java on Serverless Office Hours</h3>
         <p>James Ward and Julian Wood explore building AI-powered Java apps &mdash; MCP integration, agent architectures with AgentCore, GraalVM optimization for AI workloads, and secure auth patterns for AI services on serverless</p>
       </a>
+
+      <a class="card" href="https://www.youtube.com/watch?v=3fLCOqpIfI0">
+        <span class="card-badge badge-video">Videos</span>
+        <h3>Java for an AI World &mdash; JavaOne 2026 Opening Keynote</h3>
+        <p>Opening keynote of JavaOne 2026, featuring Rod Johnson, Josh Long, and engineering leads from Oracle, Microsoft, NVIDIA, JetBrains, and Uber on Java's AI direction, including the GitHub Copilot SDK for Java</p>
+      </a>
+
+      <a class="card" href="https://www.youtube.com/watch?v=nHnKReitDXc">
+        <span class="card-badge badge-video">Videos</span>
+        <h3>Bootiful Spring AI &mdash; Josh Long &amp; James Ward @ Spring I/O 2026</h3>
+        <p>Talk from Spring I/O 2026 in Barcelona demystifying AI integration with Spring Boot &mdash; agentic patterns, Spring AI, and MCP integration</p>
+      </a>
+
+      <div class="card">
+        <span class="card-badge badge-resource">Workshop</span>
+        <h3><a href="https://openliberty.github.io/liberty-workshop-langchain4j/">Liberty LangChain4j Workshop</a></h3>
+        <p>Hands-on, self-paced Open Liberty workshop that progresses from a simple chatbot to agentic systems using LangChain4j &mdash; prompt engineering, streaming, RAG, tool calling, MCP, guardrails/observability, and multi-agent supervisor patterns</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://openliberty.github.io/liberty-workshop-langchain4j/" title="Workshop"></a>
+          <a class="icon icon-web" href="https://openliberty.io/blog/2026/07/10/liberty-langchain4j-workshop.html" title="Blog"></a>
+        </div>
+      </div>
 
     </div>
   </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-07-21</lastmod>
+    <lastmod>2026-07-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Scheduled content update per the site's governance policy (`AGENTS.md`/`SPEC.md`). Researched and verified (via direct fetch/GitHub API, not URL-guessing) genuinely new, notable items missing from the site.

- **Agent Frameworks & Libraries:** added the official Java SDKs for OpenAI, Google Gen AI (Gemini/Vertex AI), IBM watsonx.ai, and SAP AI Core — filling a gap where Anthropic and GitHub Copilot SDKs were listed but the other major model providers weren't.
- **Java with Code Assistants:** added 4 new MCP servers/extensions — Apache Camel MCP Server, Micronaut Fun MCP Server, Develocity MCP Servers (Gradle Inc.), and AssistAI (Eclipse IDE MCP server).
- **Resources:** added the JavaOne 2026 "Java for an AI World" keynote, the "Bootiful Spring AI" talk (Josh Long & James Ward, Spring I/O 2026), and the Liberty LangChain4j Workshop.
- **News:** added 5 new headlines (TornadoVM 5.1.0 FP8 support, Quarkus voting-pattern post, Micronaut Framework 5.0.0, A2A Java SDK 1.0.0.CR1, "The Gen AI Iceberg" article) and removed the Akka Agentic Platform item, which was dated July 2025 — over a year old and outside the site's 3-month news window.
- Bumped `sitemap.xml` `<lastmod>`.

`SPEC.md` was updated first, then `index.html` and the `ItemList` JSON-LD schema to match, per `AGENTS.md`.

## Test plan
- [x] Verified every new item by fetching the actual source page/GitHub repo (not inferring from the URL)
- [x] Checked all news item dates fall within the 3-month window and re-sorted the list newest-first
- [x] Confirmed no duplicates against existing site content
- [x] Validated `index.html` parses cleanly and `<div>`/`<section>`/`<a>` tags are balanced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TtdgwnADKsru3Xifacpq1K

---
_Generated by [Claude Code](https://claude.ai/code/session_01TtdgwnADKsru3Xifacpq1K)_