### PR TITLE
Add A2A Java SDK 1.1.0, ScarfBench, and refresh news

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -86,7 +86,9 @@ Questions and answers:
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
+- https://inside.java/2026/07/25/design-java-mcp-tool/
 - https://github.com/beehive-lab/TornadoVM/releases/tag/v5.2.0-jdk21
+- https://inside.java/2026/07/23/podcast-063/
 - https://javapro.io/2026/07/16/solving-spring-ais-ui-challenge-with-ag-uis-java-sdk/
 - https://github.com/langchain4j/langchain4j/releases/tag/1.18.0
 - https://foojay.io/today/i-asked-github-copilot-to-profile-a-java-app-it-found-a-bug-in-my-heap-sizing-and-offered-to-fix-it/
@@ -94,6 +96,7 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.0.0
 - https://github.com/agentscope-ai/agentscope-java/releases/tag/v2.0.0
 - https://javapro.io/2026/07/08/langchain4j-agentic-workflows-from-ai-calls-to-multi-agent-systems-in-java/
+- https://a2aproject.github.io/a2a-java/posts/a2a-java-sdk-1-1-0-final-released/
 - https://spring.io/blog/2026/06/12/spring-ai-2-0-0-GA-available-now
 - https://java.agentscope.io/v2/en/blogs/agentscope-v2-release.html
 - https://javapro.io/2026/06/03/the-gen-ai-iceberg-java-tooling-edition/
@@ -843,6 +846,12 @@ Yes. Most Java AI frameworks run on any JVM language. Embabel is written in Kotl
 - **Badge:** Workshop
 - **Description:** Hands-on, self-paced Open Liberty workshop that progresses from a simple chatbot to agentic systems using LangChain4j — prompt engineering, streaming, RAG, tool calling, MCP, guardrails/observability, and multi-agent supervisor patterns
 - **Links:** [Workshop](https://openliberty.github.io/liberty-workshop-langchain4j/) · [Blog](https://openliberty.io/blog/2026/07/10/liberty-langchain4j-workshop.html)
+
+### ScarfBench
+
+- **Badge:** Resource
+- **Description:** IBM Research's open benchmark for evaluating AI agents on enterprise Java framework migration — 102 applications and 204 tasks (~1,331 tests) covering Jakarta EE, Quarkus, and Spring, with a public leaderboard.
+- **Links:** [GitHub](https://github.com/scarfbench/benchmark) · [Announcement](https://www.ibm.com/new/announcements/scarfbench-a-public-benchmark-for-java-framework-migration)
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -386,7 +386,9 @@
     <div class="news-bar">
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Headlines</h2>
       <ul>
+        <li><a href="https://inside.java/2026/07/25/design-java-mcp-tool/">Pairing In-Process and Hosted Embeddings for Java MCP Tool Development</a> &mdash; designing an MCP server on Helidon that supports both local (DJL/MiniLM) and hosted (OpenAI) embedding models behind a stable tool interface</li>
         <li><a href="https://github.com/beehive-lab/TornadoVM/releases/tag/v5.2.0-jdk21">TornadoVM 5.2.0 Adds Native FP8 Tensor-Core Support</a> &mdash; packed half2 support and native FP8 conversion with FP8/BF16 tensor-core MMA for the CUDA backend, plus expanded BFloat16 array support and new activation-function epilogues (SiLU, Sigmoid, Tanh, HardSwish)</li>
+        <li><a href="https://inside.java/2026/07/23/podcast-063/">Inside Java Podcast: AI Solutions with Spring AI 2.0</a> &mdash; Dan Vega and Lize Raes discuss Spring AI 2.0, deterministic agents, and MCP servers/skills, recorded at JavaOne 2026</li>
         <li><a href="https://javapro.io/2026/07/16/solving-spring-ais-ui-challenge-with-ag-uis-java-sdk/">Solving Spring AI's UI Challenge with AG-UI's Java SDK</a> &mdash; walks through bridging Spring AI agent backends with frontend UIs like CopilotKit via a standardized streaming protocol</li>
         <li><a href="https://github.com/langchain4j/langchain4j/releases/tag/1.18.0">LangChain4j 1.18.0 Released</a> &mdash; introduces a Belief-Desire-Intention (BDI) agentic pattern, crash-resilient Human-in-the-Loop suspend/resume for agentic systems, OpenAI TTS support, and a revamped embedding-model API with per-call parameters and multimodal input</li>
         <li><a href="https://foojay.io/today/i-asked-github-copilot-to-profile-a-java-app-it-found-a-bug-in-my-heap-sizing-and-offered-to-fix-it/">JVM Pulse: Profiling Java with GitHub Copilot</a> &mdash; new open-source Copilot canvas extension from Bruno Borges automates GC/JFR profiling and hands off findings to Copilot for AI-driven tuning recommendations</li>
@@ -394,6 +396,7 @@
         <li><a href="https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.0.0">Spring AI AgentCore SDK v2.0.0 Released</a> &mdash; major version release of the open-source Spring Boot integration for Amazon Bedrock AgentCore, with auto-configured invocation endpoints, SSE streaming, and short/long-term memory support</li>
         <li><a href="https://github.com/agentscope-ai/agentscope-java/releases/tag/v2.0.0">AgentScope Java v2.0.0 Tagged on GitHub</a> &mdash; formal GA release tag for the dual-layer ReActAgent/HarnessAgent architecture, a unified 28-event observability model, and a new permission engine</li>
         <li><a href="https://javapro.io/2026/07/08/langchain4j-agentic-workflows-from-ai-calls-to-multi-agent-systems-in-java/">LangChain4j Agentic Workflows: From AI Calls to Multi-Agent Systems</a> &mdash; tutorial covering sequential, loop, parallel, and conditional workflow patterns, goal-oriented planning, and supervisor-based multi-agent systems in Java</li>
+        <li><a href="https://a2aproject.github.io/a2a-java/posts/a2a-java-sdk-1-1-0-final-released/">A2A Java SDK 1.1.0.Final Released</a> &mdash; first feature release after GA, adding a TaskAuthorizationProvider SPI for per-user task authorization in multi-tenant deployments, plus a new project website</li>
         <li><a href="https://spring.io/blog/2026/06/12/spring-ai-2-0-0-GA-available-now">Spring AI 2.0.0 GA Available Now</a> &mdash; built on Spring Boot 4 with Jackson 3 JSON handling and null-safety annotations, tool calling elevated to a composable advisor-chain component for agentic patterns, and Model Context Protocol integration with annotation-driven programming and enterprise security</li>
         <li><a href="https://java.agentscope.io/v2/en/blogs/agentscope-v2-release.html">AgentScope Java v2.0.0 GA</a> &mdash; Alibaba's JVM-native agent framework reaches production-ready GA, with event-streaming, permission-gated tool execution, and a Workspace abstraction for long-running, safely sandboxed agents</li>
         <li><a href="https://javapro.io/2026/06/03/the-gen-ai-iceberg-java-tooling-edition/">The Gen AI Iceberg: Java Tooling Edition</a> &mdash; a tiered tour of Java's generative AI tooling, from mainstream frameworks like Spring AI and LangChain4j down to GPU kernel compilation and Project Babylon, arguing the JVM runs AI workloads natively rather than just calling out to them</li>
@@ -1658,6 +1661,16 @@
         <div class="card-links">
           <a class="icon icon-web" href="https://openliberty.github.io/liberty-workshop-langchain4j/" title="Workshop"></a>
           <a class="icon icon-web" href="https://openliberty.io/blog/2026/07/10/liberty-langchain4j-workshop.html" title="Blog"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-inference">Resource</span>
+        <h3><a href="https://github.com/scarfbench/benchmark">ScarfBench</a></h3>
+        <p>IBM Research's open benchmark for evaluating AI agents on enterprise Java framework migration &mdash; 102 applications and 204 tasks (~1,331 tests) covering Jakarta EE, Quarkus, and Spring, with a public leaderboard</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/scarfbench/benchmark" title="GitHub"></a>
+          <a class="icon icon-web" href="https://www.ibm.com/new/announcements/scarfbench-a-public-benchmark-for-java-framework-migration" title="Announcement"></a>
         </div>
       </div>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
Routine content update per the site's governance policy (`CONTRIBUTING.md`/`AGENTS.md`) — researched and verified missing, important Java/JVM AI ecosystem items via live fetches, updated `SPEC.md` first, then `index.html` to match.

- **News:** add Inside.java's article on pairing in-process and hosted embeddings for Java MCP tool development (2026-07-25), the Inside Java podcast episode on Spring AI 2.0 with Dan Vega (2026-07-23), and the A2A Java SDK 1.1.0.Final release (adds a `TaskAuthorizationProvider` SPI for multi-tenant task authorization)
- **Resources:** add ScarfBench — IBM Research's public benchmark for evaluating AI agents on enterprise Java framework migration (Jakarta EE/Quarkus/Spring)
- Bumped `sitemap.xml` `<lastmod>` to match

Also researched (and deliberately did **not** add, per the site's inclusion bar):
- Genkit for Java — unofficial port, still `1.0.0-SNAPSHOT`, recent activity is dependency-bumps only
- Capstead — real but very early/niche (8 GitHub stars)
- Checked several smaller existing entries (Deliverance, JamJet, OmniHai, Atmosphere, ClawRunr, Tools4AI) for abandonment signals — none found; all still active

All additions were verified against primary sources (GitHub, official blogs) for accuracy and current dates before inclusion.

## Test plan
- [x] `SPEC.md` updated first, `index.html` updated to match per `AGENTS.md` process
- [x] HTML structure validated (balanced tags via `html.parser`)
- [x] News item dates verified via live fetch to confirm correct newest-first ordering and the 3-month window
- [ ] Visual review in browser (no build step; open `index.html` directly)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JEgiLT3H4HFWfdUTD1biDZ)_