### PR TITLE
Add Embabel 1.0.0 GA release to news

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -86,6 +86,7 @@ Questions and answers:
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
+- https://github.com/embabel/embabel-agent/releases/tag/v1.0.0
 - https://github.com/beehive-lab/TornadoVM/releases/tag/v5.2.0-jdk21
 - https://javapro.io/2026/07/16/solving-spring-ais-ui-challenge-with-ag-uis-java-sdk/
 - https://github.com/langchain4j/langchain4j/releases/tag/1.18.0

--- a/index.html
+++ b/index.html
@@ -386,6 +386,7 @@
     <div class="news-bar">
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Headlines</h2>
       <ul>
+        <li><a href="https://github.com/embabel/embabel-agent/releases/tag/v1.0.0">Embabel 1.0.0 Reaches GA</a> &mdash; the JVM agent framework's first stable release promotes experimental RAG APIs to production status, adds generic media/document support, exposes MCP server health via Spring Boot Actuator, and now resolves entirely from Maven Central</li>
         <li><a href="https://github.com/beehive-lab/TornadoVM/releases/tag/v5.2.0-jdk21">TornadoVM 5.2.0 Adds Native FP8 Tensor-Core Support</a> &mdash; packed half2 support and native FP8 conversion with FP8/BF16 tensor-core MMA for the CUDA backend, plus expanded BFloat16 array support and new activation-function epilogues (SiLU, Sigmoid, Tanh, HardSwish)</li>
         <li><a href="https://javapro.io/2026/07/16/solving-spring-ais-ui-challenge-with-ag-uis-java-sdk/">Solving Spring AI's UI Challenge with AG-UI's Java SDK</a> &mdash; walks through bridging Spring AI agent backends with frontend UIs like CopilotKit via a standardized streaming protocol</li>
         <li><a href="https://github.com/langchain4j/langchain4j/releases/tag/1.18.0">LangChain4j 1.18.0 Released</a> &mdash; introduces a Belief-Desire-Intention (BDI) agentic pattern, crash-resilient Human-in-the-Loop suspend/resume for agentic systems, OpenAI TTS support, and a revamped embedding-model API with per-call parameters and multimodal input</li>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-07-25</lastmod>
+    <lastmod>2026-07-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Add Embabel's first stable 1.0.0 GA release (July 20, 2026) to the News section — promotes experimental RAG APIs to production status, adds generic media/document support, exposes MCP server health via Spring Boot Actuator, and now resolves entirely from Maven Central.
- Bumped `sitemap.xml` `<lastmod>` per site convention.

## Research notes
Checked for other missing/new items per the site's governance policy (AGENTS.md/CONTRIBUTING.md/SPEC.md) since the last update two days ago — no other verifiable, in-scope additions, removals, or abandonment-status changes were found (Quarkus/Micronaut/Spring blogs, javapro.io, foojay.io, and GitHub/Maven searches for new Java-specific frameworks, SDKs, and MCP servers all came up empty or below the site's relevance bar).

## Test plan
- [x] Followed AGENTS.md process: `SPEC.md` updated first, then `index.html` to match
- [x] Verified facts via direct fetch of the GitHub release page and announcement blog post (not inferred)
- [ ] Visual/local validation of `index.html` rendering

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01WrXTKTMok63ghKQo2UotRe

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrXTKTMok63ghKQo2UotRe)_