### PR TITLE
Add James Ward interview on Java and AI in 2026

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -872,6 +872,12 @@ Yes. Most Java AI frameworks run on any JVM language. Embabel is written in Kotl
 - **Description:** Talk from Spring I/O 2026 in Barcelona demystifying AI integration with Spring Boot — agentic patterns, Spring AI, and MCP integration
 - **Links:** https://www.youtube.com/watch?v=nHnKReitDXc
 
+### Java and AI in 2026 and Beyond — James Ward Interview
+
+- **Badge:** Videos
+- **Description:** 68-minute interview with James Ward on the Code With Ease channel, recorded at GIDS Bangalore — the Java AI landscape from Spring AI, LangChain4j, Koog, and Embabel to MCP, agent memory, RAG vs tools vs skills, and production deployment with AWS AgentCore
+- **Links:** https://www.youtube.com/watch?v=-TWXNYRE0Q8
+
 ### Liberty LangChain4j Workshop
 
 - **Badge:** Workshop

--- a/index.html
+++ b/index.html
@@ -1710,6 +1710,12 @@
         <p>Talk from Spring I/O 2026 in Barcelona demystifying AI integration with Spring Boot &mdash; agentic patterns, Spring AI, and MCP integration</p>
       </a>
 
+      <a class="card" href="https://www.youtube.com/watch?v=-TWXNYRE0Q8">
+        <span class="card-badge badge-video">Videos</span>
+        <h3>Java and AI in 2026 and Beyond &mdash; James Ward Interview</h3>
+        <p>68-minute interview with James Ward on the Code With Ease channel, recorded at GIDS Bangalore &mdash; the Java AI landscape from Spring AI, LangChain4j, Koog, and Embabel to MCP, agent memory, RAG vs tools vs skills, and production deployment with AWS AgentCore</p>
+      </a>
+
       <div class="card">
         <span class="card-badge badge-resource">Workshop</span>
         <h3><a href="https://openliberty.github.io/liberty-workshop-langchain4j/">Liberty LangChain4j Workshop</a></h3>


### PR DESCRIPTION
## Summary
Added a new video resource documenting James Ward's interview on the Java AI landscape, recorded at GIDS Bangalore on the Code With Ease channel.

## Changes
- Added new video entry "Java and AI in 2026 and Beyond — James Ward Interview" to both SPEC.md and index.html
- The 68-minute interview covers key topics including Spring AI, LangChain4j, Koog, Embabel, MCP, agent memory, RAG vs tools vs skills, and production deployment with AWS AgentCore
- Positioned the new entry after the "Bootiful Spring AI" talk and before the "Liberty LangChain4j Workshop" section to maintain logical grouping of Spring/Java AI content

## Details
- Video link: https://www.youtube.com/watch?v=-TWXNYRE0Q8
- Categorized under "Videos" badge
- Maintains consistent formatting with existing resource entries in both documentation and HTML files

https://claude.ai/code/session_01K3zBkvztyMdq7byYfz5qi9