### PR TITLE
Add Apache Camel LangChain4j components found via governance review

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -381,6 +381,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** Official Testcontainers-for-Java module for spinning up disposable Ollama containers in integration tests — pull models and commit custom images for reuse. Commonly paired with Spring AI, LangChain4j, and Quarkus LangChain4j to test local-LLM code paths.
 - **Links:** [Docs](https://java.testcontainers.org/modules/ollama/) · [GitHub](https://github.com/testcontainers/testcontainers-java/tree/main/modules/ollama)
 
+### Camel LangChain4j Components
+- **Badge:** Framework
+- **Description:** Official Apache Camel components that let Camel routes call any LangChain4j-supported LLM. The chat component (since Camel 4.5) covers single, prompted, and multi-turn LLM calls with RAG enrichment; the agent component (since Camel 4.14) adds stateful/stateless AI agents that can invoke Camel routes as tools (via `ai-tool`) plus MCP client integration. Producer-only endpoints (`langchain4j-chat:id`, `langchain4j-agent:id`) fit naturally into existing integration pipelines.
+- **Links:** [Chat Component Docs](https://camel.apache.org/components/next/langchain4j-chat-component.html) · [Agent Component Docs](https://camel.apache.org/components/next/langchain4j-agent-component.html) · [GitHub](https://github.com/apache/camel)
+
 ---
 
 ## Java with Code Assistants

--- a/index.html
+++ b/index.html
@@ -107,7 +107,8 @@
       {"@type": "ListItem", "position": 50, "name": "AWS SDK for Java v2 — Bedrock", "url": "https://github.com/aws/aws-sdk-java-v2"},
       {"@type": "ListItem", "position": 51, "name": "Qdrant Java Client", "url": "https://github.com/qdrant/java-client"},
       {"@type": "ListItem", "position": 52, "name": "Weaviate Java Client", "url": "https://github.com/weaviate/java-client"},
-      {"@type": "ListItem", "position": 53, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"}
+      {"@type": "ListItem", "position": 53, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"},
+      {"@type": "ListItem", "position": 54, "name": "Camel LangChain4j Components", "url": "https://camel.apache.org/components/next/langchain4j-chat-component.html"}
     ]
   }
   </script>
@@ -955,6 +956,17 @@
         <div class="card-links">
           <a class="icon icon-web" href="https://java.testcontainers.org/modules/ollama/" title="Docs"></a>
           <a class="icon icon-github" href="https://github.com/testcontainers/testcontainers-java/tree/main/modules/ollama" title="GitHub"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-framework">Framework</span>
+        <h3><a href="https://camel.apache.org/components/next/langchain4j-chat-component.html">Camel LangChain4j Components</a></h3>
+        <p>Official Apache Camel components that let Camel routes call any LangChain4j-supported LLM. The chat component (since Camel 4.5) covers single, prompted, and multi-turn LLM calls with RAG enrichment; the agent component (since Camel 4.14) adds stateful/stateless AI agents that can invoke Camel routes as tools (via <code>ai-tool</code>) plus MCP client integration. Producer-only endpoints (<code>langchain4j-chat:id</code>, <code>langchain4j-agent:id</code>) fit naturally into existing integration pipelines.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://camel.apache.org/components/next/langchain4j-chat-component.html" title="Chat Component Docs"></a>
+          <a class="icon icon-web" href="https://camel.apache.org/components/next/langchain4j-agent-component.html" title="Agent Component Docs"></a>
+          <a class="icon icon-github" href="https://github.com/apache/camel" title="GitHub"></a>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Scheduled review of the Java/JVM AI ecosystem against `CONTRIBUTING.md`'s governance criteria (Java/JVM-specific, actively maintained, relevant to >10% of Java AI developers). Checked:

- **News freshness** — all 24 current news items verified to fall within the 3-month window (fetched the 4 items with no visible date in the URL: all published May–July 2026). No pruning needed.
- **Fresh news since yesterday's review (PR #82)** — searched LangChain4j/Quarkus/Spring/foojay/javapro/TornadoVM for 2026-07-28 through 2026-07-30. Nothing that's both Java-AI-specific and distinct from what's already listed cleared the bar (a LangChain4j 1.18.1 patch release and a non-AI Quarkus 3.38 release were the closest candidates; both skipped as not warranting their own entry).
- **Abandonment spot-check** — Jlama, Deliverance, TDA, and JamJet checked for activity; only Jlama is stale, and it already carries the `⚠️ No longer actively maintained` note.
- **Missing resources** — found one addition below.

**Agent Frameworks & Libraries**
- **Camel LangChain4j Components** — official Apache Camel `langchain4j-chat` (since Camel 4.5) and `langchain4j-agent` (since Camel 4.14) components, letting Camel integration routes call any LangChain4j-supported LLM with chat, RAG, tool calling (including Camel routes as tools), and MCP client support. Apache Camel is one of the most widely used Java integration frameworks, so this fills a real gap — it's distinct from the already-listed "Apache Camel MCP Server" (that one is dev-tooling for AI agents *working on* Camel projects, not this AI-integration component suite for Camel routes *calling* LLMs).

`sitemap.xml` `<lastmod>` bumped per the SEO guidelines in `SPEC.md`.

## Test plan
- [x] `SPEC.md` updated first, `index.html` updated to match, per `AGENTS.md` process
- [x] New links fetched and verified (not guessed) before inclusion
- [x] `index.html` validated as well-formed (no unclosed/mismatched tags) via `html.parser`
- [ ] Visual review in a browser (not done in this environment — no build step, so a maintainer can open `index.html` directly)

---
_Generated by [Claude Code](https://claude.ai/code/session_019k1bs8cY3cFA5UBMUk2VZh)_