### PR TITLE
Add Graal Script Agent

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -87,6 +87,7 @@ Latest headlines about the Java AI ecosystem. Each item has a link and brief des
 Note: Order by date, newest first. Don't show news older than 3 months
 
 - https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/
+- https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54
 - https://inside.java/2026/07/25/design-java-mcp-tool/
 - https://github.com/embabel/embabel-agent/releases/tag/v1.0.0
 - https://github.com/beehive-lab/TornadoVM/releases/tag/v5.2.0-jdk21
@@ -204,6 +205,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Badge:** SDK
 - **Description:** Official Java SDK for embedding the GitHub Copilot agentic engine directly into Java applications. Uses the same agentic harness that powers the Copilot CLI — exposes planning, tool calling, file editing, and MCP integration via a simple Java API. Currently in technical preview.
 - **Links:** [Docs](https://github.github.com/copilot-sdk-java/) · [GitHub](https://github.com/github/copilot-sdk-java)
+
+### Graal Script Agent
+- **Badge:** Library
+- **Description:** Early-preview Java library for adding prompt-authored extensions to Java applications. Developers define where an application can be extended; users prompt for the behavior they need. It produces reusable JavaScript or Python extensions that execute locally in a sandbox without another model call.
+- **Links:** [Docs](https://graalvm.github.io/graal-script-agent/latest/) · [GitHub](https://github.com/graalvm/graal-script-agent) · [Blog](https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54)
 
 ### Tracy (JetBrains)
 - **Badge:** Library

--- a/index.html
+++ b/index.html
@@ -73,40 +73,41 @@
       {"@type": "ListItem", "position": 16, "name": "MCP Java SDK", "url": "https://modelcontextprotocol.io/sdk/java/mcp-overview"},
       {"@type": "ListItem", "position": 17, "name": "Anthropic Java SDK", "url": "https://github.com/anthropics/anthropic-sdk-java"},
       {"@type": "ListItem", "position": 18, "name": "GitHub Copilot SDK for Java", "url": "https://github.github.com/copilot-sdk-java/"},
-      {"@type": "ListItem", "position": 19, "name": "Tracy (JetBrains)", "url": "https://jetbrains.github.io/tracy/latest"},
-      {"@type": "ListItem", "position": 20, "name": "Docling Java", "url": "https://docling-project.github.io/docling-java/current"},
-      {"@type": "ListItem", "position": 21, "name": "OmniHai", "url": "https://omnihai.org"},
-      {"@type": "ListItem", "position": 22, "name": "ACP Langchain4j bridge", "url": "https://github.com/OsgiliathEnterprise/acp-langgraph-langchain-bridge"},
-      {"@type": "ListItem", "position": 23, "name": "A2A Java SDK", "url": "https://github.com/a2aproject/a2a-java"},
-      {"@type": "ListItem", "position": 24, "name": "A2A Java SDK for Jakarta Servers", "url": "https://github.com/wildfly-extras/a2a-java-sdk-server-jakarta"},
-      {"@type": "ListItem", "position": 25, "name": "WildFly AI Feature Pack", "url": "https://github.com/wildfly-extras/wildfly-ai-feature-pack"},
-      {"@type": "ListItem", "position": 26, "name": "MCP_JAVA Annotations", "url": "https://github.com/mcp-java/java-mcp-annotations"},
-      {"@type": "ListItem", "position": 27, "name": "Atmosphere", "url": "https://atmosphere.github.io/docs/"},
-      {"@type": "ListItem", "position": 28, "name": "Spring AI Agent Utils", "url": "https://springaicommunity.mintlify.app/projects/incubating/spring-ai-agent-utils"},
-      {"@type": "ListItem", "position": 29, "name": "Jakarta Agentic AI", "url": "https://github.com/jakartaee/agentic-ai"},
-      {"@type": "ListItem", "position": 30, "name": "AgentScope Java", "url": "https://java.agentscope.io/"},
-      {"@type": "ListItem", "position": 31, "name": "JVector", "url": "https://github.com/datastax/jvector"},
-      {"@type": "ListItem", "position": 32, "name": "Milvus Java SDK", "url": "https://github.com/milvus-io/milvus-sdk-java"},
-      {"@type": "ListItem", "position": 33, "name": "ClawRunr", "url": "https://github.com/ClawRunr/JavaClaw"},
-      {"@type": "ListItem", "position": 34, "name": "MCP Toolbox Java SDK", "url": "https://github.com/googleapis/mcp-toolbox-sdk-java"},
-      {"@type": "ListItem", "position": 35, "name": "Tools4AI", "url": "https://github.com/vishalmysore/Tools4AI"},
-      {"@type": "ListItem", "position": 36, "name": "EclipseStore", "url": "https://github.com/eclipse-store/store"},
-      {"@type": "ListItem", "position": 37, "name": "OpenAI Java SDK", "url": "https://github.com/openai/openai-java"},
-      {"@type": "ListItem", "position": 38, "name": "Google Gen AI Java SDK", "url": "https://github.com/googleapis/java-genai"},
-      {"@type": "ListItem", "position": 39, "name": "IBM watsonx.ai Java SDK", "url": "https://github.com/IBM/watsonx-ai-java-sdk"},
-      {"@type": "ListItem", "position": 40, "name": "SAP AI SDK for Java", "url": "https://github.com/SAP/ai-sdk-java"},
-      {"@type": "ListItem", "position": 41, "name": "Tiberius", "url": "https://github.com/tiberius-security/tiberius"},
-      {"@type": "ListItem", "position": 42, "name": "Ollama4j", "url": "https://github.com/ollama4j/ollama4j"},
-      {"@type": "ListItem", "position": 43, "name": "Cohere Java SDK", "url": "https://github.com/cohere-ai/cohere-java"},
-      {"@type": "ListItem", "position": 44, "name": "kyo-ai", "url": "https://github.com/getkyo/kyo-ai"},
-      {"@type": "ListItem", "position": 45, "name": "zio-bedrock-converse", "url": "https://github.com/jamesward/zio-bedrock-converse"},
-      {"@type": "ListItem", "position": 46, "name": "zio-http-mcp", "url": "https://github.com/jamesward/zio-http-mcp"},
-      {"@type": "ListItem", "position": 47, "name": "Tachyon", "url": "https://github.com/kpavlov/tachyon"},
-      {"@type": "ListItem", "position": 48, "name": "Solon-AI", "url": "https://github.com/opensolon/solon-ai"},
-      {"@type": "ListItem", "position": 49, "name": "AWS SDK for Java v2 — Bedrock", "url": "https://github.com/aws/aws-sdk-java-v2"},
-      {"@type": "ListItem", "position": 50, "name": "Qdrant Java Client", "url": "https://github.com/qdrant/java-client"},
-      {"@type": "ListItem", "position": 51, "name": "Weaviate Java Client", "url": "https://github.com/weaviate/java-client"},
-      {"@type": "ListItem", "position": 52, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"}
+      {"@type": "ListItem", "position": 19, "name": "Graal Script Agent", "url": "https://graalvm.github.io/graal-script-agent/latest/"},
+      {"@type": "ListItem", "position": 20, "name": "Tracy (JetBrains)", "url": "https://jetbrains.github.io/tracy/latest"},
+      {"@type": "ListItem", "position": 21, "name": "Docling Java", "url": "https://docling-project.github.io/docling-java/current"},
+      {"@type": "ListItem", "position": 22, "name": "OmniHai", "url": "https://omnihai.org"},
+      {"@type": "ListItem", "position": 23, "name": "ACP Langchain4j bridge", "url": "https://github.com/OsgiliathEnterprise/acp-langgraph-langchain-bridge"},
+      {"@type": "ListItem", "position": 24, "name": "A2A Java SDK", "url": "https://github.com/a2aproject/a2a-java"},
+      {"@type": "ListItem", "position": 25, "name": "A2A Java SDK for Jakarta Servers", "url": "https://github.com/wildfly-extras/a2a-java-sdk-server-jakarta"},
+      {"@type": "ListItem", "position": 26, "name": "WildFly AI Feature Pack", "url": "https://github.com/wildfly-extras/wildfly-ai-feature-pack"},
+      {"@type": "ListItem", "position": 27, "name": "MCP_JAVA Annotations", "url": "https://github.com/mcp-java/java-mcp-annotations"},
+      {"@type": "ListItem", "position": 28, "name": "Atmosphere", "url": "https://atmosphere.github.io/docs/"},
+      {"@type": "ListItem", "position": 29, "name": "Spring AI Agent Utils", "url": "https://springaicommunity.mintlify.app/projects/incubating/spring-ai-agent-utils"},
+      {"@type": "ListItem", "position": 30, "name": "Jakarta Agentic AI", "url": "https://github.com/jakartaee/agentic-ai"},
+      {"@type": "ListItem", "position": 31, "name": "AgentScope Java", "url": "https://java.agentscope.io/"},
+      {"@type": "ListItem", "position": 32, "name": "JVector", "url": "https://github.com/datastax/jvector"},
+      {"@type": "ListItem", "position": 33, "name": "Milvus Java SDK", "url": "https://github.com/milvus-io/milvus-sdk-java"},
+      {"@type": "ListItem", "position": 34, "name": "ClawRunr", "url": "https://github.com/ClawRunr/JavaClaw"},
+      {"@type": "ListItem", "position": 35, "name": "MCP Toolbox Java SDK", "url": "https://github.com/googleapis/mcp-toolbox-sdk-java"},
+      {"@type": "ListItem", "position": 36, "name": "Tools4AI", "url": "https://github.com/vishalmysore/Tools4AI"},
+      {"@type": "ListItem", "position": 37, "name": "EclipseStore", "url": "https://github.com/eclipse-store/store"},
+      {"@type": "ListItem", "position": 38, "name": "OpenAI Java SDK", "url": "https://github.com/openai/openai-java"},
+      {"@type": "ListItem", "position": 39, "name": "Google Gen AI Java SDK", "url": "https://github.com/googleapis/java-genai"},
+      {"@type": "ListItem", "position": 40, "name": "IBM watsonx.ai Java SDK", "url": "https://github.com/IBM/watsonx-ai-java-sdk"},
+      {"@type": "ListItem", "position": 41, "name": "SAP AI SDK for Java", "url": "https://github.com/SAP/ai-sdk-java"},
+      {"@type": "ListItem", "position": 42, "name": "Tiberius", "url": "https://github.com/tiberius-security/tiberius"},
+      {"@type": "ListItem", "position": 43, "name": "Ollama4j", "url": "https://github.com/ollama4j/ollama4j"},
+      {"@type": "ListItem", "position": 44, "name": "Cohere Java SDK", "url": "https://github.com/cohere-ai/cohere-java"},
+      {"@type": "ListItem", "position": 45, "name": "kyo-ai", "url": "https://github.com/getkyo/kyo-ai"},
+      {"@type": "ListItem", "position": 46, "name": "zio-bedrock-converse", "url": "https://github.com/jamesward/zio-bedrock-converse"},
+      {"@type": "ListItem", "position": 47, "name": "zio-http-mcp", "url": "https://github.com/jamesward/zio-http-mcp"},
+      {"@type": "ListItem", "position": 48, "name": "Tachyon", "url": "https://github.com/kpavlov/tachyon"},
+      {"@type": "ListItem", "position": 49, "name": "Solon-AI", "url": "https://github.com/opensolon/solon-ai"},
+      {"@type": "ListItem", "position": 50, "name": "AWS SDK for Java v2 — Bedrock", "url": "https://github.com/aws/aws-sdk-java-v2"},
+      {"@type": "ListItem", "position": 51, "name": "Qdrant Java Client", "url": "https://github.com/qdrant/java-client"},
+      {"@type": "ListItem", "position": 52, "name": "Weaviate Java Client", "url": "https://github.com/weaviate/java-client"},
+      {"@type": "ListItem", "position": 53, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"}
     ]
   }
   </script>
@@ -398,6 +399,7 @@
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Headlines</h2>
       <ul>
         <li><a href="https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/">Connecting Java Reinforcement Learning to Python Gymnasium</a> &mdash; bridges Java RL code to Python's Gymnasium library via JavaCPP, covering Python lifecycle management and NumPy data transfer, starting with CartPole before scaling up to CARLA</li>
+        <li><a href="https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54">When Prompts Become Plugins: Generating User Extensions with Graal Script Agent</a> &mdash; introduces a library for turning end-user prompts into sandboxed, reusable JavaScript or Python extensions that run locally within application-defined boundaries</li>
         <li><a href="https://inside.java/2026/07/25/design-java-mcp-tool/">Pairing In-Process and Hosted Embeddings for Java MCP Tool Development</a> &mdash; designing an MCP server on Helidon that supports both local (DJL/MiniLM) and hosted (OpenAI) embedding models behind a stable tool interface</li>
         <li><a href="https://github.com/embabel/embabel-agent/releases/tag/v1.0.0">Embabel 1.0.0 Reaches GA</a> &mdash; the JVM agent framework's first stable release promotes experimental RAG APIs to production status, adds generic media/document support, exposes MCP server health via Spring Boot Actuator, and now resolves entirely from Maven Central</li>
         <li><a href="https://github.com/beehive-lab/TornadoVM/releases/tag/v5.2.0-jdk21">TornadoVM 5.2.0 Adds Native FP8 Tensor-Core Support</a> &mdash; packed half2 support and native FP8 conversion with FP8/BF16 tensor-core MMA for the CUDA backend, plus expanded BFloat16 array support and new activation-function epilogues (SiLU, Sigmoid, Tanh, HardSwish)</li>
@@ -612,6 +614,17 @@
         <div class="card-links">
           <a class="icon icon-web" href="https://github.github.com/copilot-sdk-java/" title="Docs"></a>
           <a class="icon icon-github" href="https://github.com/github/copilot-sdk-java" title="GitHub"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-inference">Library</span>
+        <h3><a href="https://graalvm.github.io/graal-script-agent/latest/">Graal Script Agent</a></h3>
+        <p>Early-preview Java library for adding prompt-authored extensions to Java applications. Developers define where an application can be extended; users prompt for the behavior they need. It produces reusable JavaScript or Python extensions that execute locally in a sandbox without another model call.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://graalvm.github.io/graal-script-agent/latest/" title="Docs"></a>
+          <a class="icon icon-github" href="https://github.com/graalvm/graal-script-agent" title="GitHub"></a>
+          <a class="icon icon-web" href="https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54" title="Blog"></a>
         </div>
       </div>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-07-29</lastmod>
+    <lastmod>2026-07-30</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
This PR adds [Graal Script Agent](https://github.com/graalvm/graal-script-agent), a Java library for adding prompt-authored extensions to Java applications. Applications define the permitted extension points and APIs, while generated JavaScript or Python extensions execute locally within GraalVM sandbox boundaries.

Also adds the [related blog post](https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54) to News.