### PR TITLE
Add MongoDB planning-pattern news, Akka autonomous agents update, Otavio Santana

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -100,6 +100,7 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.0.0
 - https://github.com/agentscope-ai/agentscope-java/releases/tag/v2.0.0
 - https://javapro.io/2026/07/08/langchain4j-agentic-workflows-from-ai-calls-to-multi-agent-systems-in-java/
+- https://foojay.io/today/building-ai-systems-with-mongodb-implementing-the-planning-pattern/
 - https://a2aproject.github.io/a2a-java/posts/a2a-java-sdk-1-1-0-final-released/
 - https://quarkus.io/blog/a2a-java-sdk-1-0-0-final-released/
 - https://spring.io/blog/2026/06/12/spring-ai-2-0-0-GA-available-now
@@ -168,7 +169,7 @@ Note: Order by date, newest first. Don't show news older than 3 months
 
 ### Akka Agents
 - **Badge:** Framework
-- **Description:** Agentic AI platform built on Akka's actor model for distributed, resilient systems. Declarative Effects API for building goal-directed agents with durable memory, multi-agent orchestration, and automatic scaling. MCP and A2A protocol support, pluggable LLM providers, runtime prompt updates, and agents auto-exposed as HTTP, gRPC, or MCP endpoints. Java and Scala SDKs.
+- **Description:** Agentic AI platform built on Akka's actor model for distributed, resilient systems. Declarative Effects API for building goal-directed agents with durable memory, multi-agent orchestration, and automatic scaling. Task-based autonomous agents with pause/resume/terminate lifecycle control and task result subscriptions, alongside request-based agents. MCP and A2A protocol support, pluggable LLM providers, runtime prompt updates, and agents auto-exposed as HTTP, gRPC, or MCP endpoints. Java and Scala SDKs.
 - **Links:** [Docs](https://doc.akka.io/) · [GitHub](https://github.com/akka/akka-sdk) · [Website](https://akka.io/akka-agents)
 
 ### Koog (JetBrains)
@@ -798,6 +799,15 @@ Notes:
 - **Photo:** https://avatars.githubusercontent.com/u/247332?v=4
 - **Role:** Developer Advocate at Tessl, co-author of *Liquid Software* and *DevOps Tools for Java Developers*
 - **Links:** [@jbaruch](https://twitter.com/jbaruch) · [Bluesky](https://bsky.app/profile/jbaru.ch) · [GitHub](https://github.com/jbaruch) · [LinkedIn](https://www.linkedin.com/in/jbaruch/) · [Website](https://speaking.jbaru.ch)
+
+### Otavio Santana
+
+- **Badge:** Person
+- **Java Champion**
+- **Initials:** OS
+- **Photo:** https://avatars.githubusercontent.com/u/863011?v=4
+- **Role:** Jakarta Data/Jakarta NoSQL spec lead, Eclipse JNoSQL creator, writes on building AI agents with Jakarta EE and LangChain4j
+- **Links:** [@otaviojava](https://twitter.com/otaviojava) · [GitHub](https://github.com/otaviojava) · [LinkedIn](https://www.linkedin.com/in/otaviojava/) · [Website](https://otaviojava.com/) · [YouTube](https://www.youtube.com/@otaviojava)
 
 ### Oleg Šelajev
 

--- a/index.html
+++ b/index.html
@@ -413,6 +413,7 @@
         <li><a href="https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.0.0">Spring AI AgentCore SDK v2.0.0 Released</a> &mdash; major version release of the open-source Spring Boot integration for Amazon Bedrock AgentCore, with auto-configured invocation endpoints, SSE streaming, and short/long-term memory support</li>
         <li><a href="https://github.com/agentscope-ai/agentscope-java/releases/tag/v2.0.0">AgentScope Java v2.0.0 Tagged on GitHub</a> &mdash; formal GA release tag for the dual-layer ReActAgent/HarnessAgent architecture, a unified 28-event observability model, and a new permission engine</li>
         <li><a href="https://javapro.io/2026/07/08/langchain4j-agentic-workflows-from-ai-calls-to-multi-agent-systems-in-java/">LangChain4j Agentic Workflows: From AI Calls to Multi-Agent Systems</a> &mdash; tutorial covering sequential, loop, parallel, and conditional workflow patterns, goal-oriented planning, and supervisor-based multi-agent systems in Java</li>
+        <li><a href="https://foojay.io/today/building-ai-systems-with-mongodb-implementing-the-planning-pattern/">Building AI Systems with MongoDB: Implementing the Planning Pattern</a> &mdash; tutorial building a travel-itinerary AI agent with Jakarta EE, Jakarta Data, LangChain4j, and MongoDB using a Reason-Act-Observe planning loop</li>
         <li><a href="https://a2aproject.github.io/a2a-java/posts/a2a-java-sdk-1-1-0-final-released/">A2A Java SDK 1.1.0.Final Released</a> &mdash; first feature release after GA, adding a TaskAuthorizationProvider SPI for per-user task authorization in multi-tenant deployments, plus a new project website</li>
         <li><a href="https://quarkus.io/blog/a2a-java-sdk-1-0-0-final-released/">A2A Java SDK Reaches 1.0 GA</a> &mdash; the Agent2Agent Java SDK ships 1.0.0.Final with spec classes converted to Java records, full JSON-RPC/gRPC/REST transport support, and a cross-SDK interop test kit, followed by 1.1.0 adding a <code>TaskAuthorizationProvider</code> SPI for per-user task authorization</li>
         <li><a href="https://spring.io/blog/2026/06/12/spring-ai-2-0-0-GA-available-now">Spring AI 2.0.0 GA Available Now</a> &mdash; built on Spring Boot 4 with Jackson 3 JSON handling and null-safety annotations, tool calling elevated to a composable advisor-chain component for agentic patterns, and Model Context Protocol integration with annotation-driven programming and enterprise security</li>
@@ -540,7 +541,7 @@
       <div class="card">
         <span class="card-badge badge-framework">Framework</span>
         <h3><a href="https://akka.io/akka-agents">Akka Agents</a></h3>
-        <p>Agentic AI platform built on Akka's actor model for distributed, resilient systems. Declarative Effects API for building goal-directed agents with durable memory, multi-agent orchestration, and automatic scaling. MCP and A2A protocol support, pluggable LLM providers, runtime prompt updates, and agents auto-exposed as HTTP, gRPC, or MCP endpoints. Java and Scala SDKs.</p>
+        <p>Agentic AI platform built on Akka's actor model for distributed, resilient systems. Declarative Effects API for building goal-directed agents with durable memory, multi-agent orchestration, and automatic scaling. Task-based autonomous agents with pause/resume/terminate lifecycle control and task result subscriptions, alongside request-based agents. MCP and A2A protocol support, pluggable LLM providers, runtime prompt updates, and agents auto-exposed as HTTP, gRPC, or MCP endpoints. Java and Scala SDKs.</p>
         <div class="card-links">
           <a class="icon icon-web" href="https://doc.akka.io/" title="Docs"></a>
           <a class="icon icon-github" href="https://github.com/akka/akka-sdk" title="GitHub"></a>
@@ -1667,6 +1668,22 @@
             <a class="icon icon-github" href="https://github.com/jbaruch" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://www.linkedin.com/in/jbaruch/" title="LinkedIn"></a>
             <a class="icon icon-web" href="https://speaking.jbaru.ch" title="Website"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/863011?v=4" alt="Otavio Santana"></div>
+        <div class="person-info">
+          <h4>Otavio Santana</h4>
+          <span class="badge-champion">Java Champion</span>
+          <p>Jakarta Data/Jakarta NoSQL spec lead, Eclipse JNoSQL creator, writes on building AI agents with Jakarta EE and LangChain4j</p>
+          <div class="person-links">
+            <a class="icon icon-x" href="https://twitter.com/otaviojava" title="@otaviojava"></a>
+            <a class="icon icon-github" href="https://github.com/otaviojava" title="GitHub"></a>
+            <a class="icon icon-linkedin" href="https://www.linkedin.com/in/otaviojava/" title="LinkedIn"></a>
+            <a class="icon icon-web" href="https://otaviojava.com/" title="Website"></a>
+            <a class="icon icon-youtube" href="https://www.youtube.com/@otaviojava" title="YouTube"></a>
           </div>
         </div>
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-07-30</lastmod>
+    <lastmod>2026-07-31</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
Daily governance review per `AGENTS.md`/`CONTRIBUTING.md` — found and added the following:

- **News:** Added [Building AI Systems with MongoDB: Implementing the Planning Pattern](https://foojay.io/today/building-ai-systems-with-mongodb-implementing-the-planning-pattern/) by Otavio Santana — a Jakarta EE + Jakarta Data + LangChain4j + MongoDB tutorial building an AI planning-pattern agent.
- **Agent Frameworks:** Updated the **Akka Agents** description to reflect Akka SDK [v3.6.0](https://github.com/akka/akka-sdk/releases/tag/v3.6.0), which introduced task-based autonomous agents with pause/resume/terminate lifecycle control and task result subscriptions.
- **People to Follow:** Added **Otavio Santana** (Java Champion, Jakarta Data/Jakarta NoSQL spec lead, Eclipse JNoSQL creator) for his recurring Java + AI writing (Jakarta EE/LangChain4j agent tutorials).

Also bumped `sitemap.xml`'s `<lastmod>` to match the content change, per spec.

Verified no other tracked projects had undisclosed GA releases and spot-checked several smaller entries (Deliverance, Graal Script Agent, OmniHai, AI-Git-Bot, ClawRunr) for abandonment — all show active recent commits, so no "no longer maintained" notes were needed this round.

`SPEC.md` was updated first, then `index.html` regenerated to match, per the process in `AGENTS.md`.

## Test plan
- [x] Diffed `SPEC.md` and `index.html` to confirm they stay in sync
- [x] Verified all new links resolve to the content described (fetched each source page directly, per `AGENTS.md`'s no-guessing rule)
- [x] Confirmed alphabetical ordering preserved in People to Follow (Sadogursky → Santana → Šelajev)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqbZ2zTSzCCL18rX67nLpL)_