### PR TITLE
Add TornadoVM, Ivar Grimstad, Daniel Oh, Susanne Pieterse, and Deep Netts news found via governance review

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -535,6 +535,11 @@ Run models, train classifiers, and do ML inference directly on the JVM — no Py
 - **Description:** Java-native LLM inference with automatic GPU acceleration via TornadoVM. Supports Llama 3, Mistral, Qwen, Phi-3, and IBM Granite models in GGUF format. TornadoVM translates Java bytecode to GPU kernels (OpenCL, PTX, SPIR-V). From the University of Manchester's Beehive Lab.
 - **Links:** [InfoQ](https://www.infoq.com/news/2025/06/gpullama3-java-gpu-llm/)
 
+### TornadoVM
+- **Badge:** Inference
+- **Description:** GPU programming framework for Java — JIT-compiles Java bytecode into CUDA, OpenCL, and Apple Metal at runtime, running on GPUs and multi-core CPUs. Powers GPULlama3.java's GPU acceleration. v5.2.0 added AI-focused kernels: native FP8 conversion, FP8/BF16 tensor-core matrix multiply, cuBLAS/CUTLASS-compatible BFloat16 arrays, and batched FP16 GEMM. From the University of Manchester's Beehive Lab.
+- **Links:** [Website](https://www.tornadovm.org) · [GitHub](https://github.com/beehive-lab/TornadoVM) · [Docs](https://tornadovm.readthedocs.io/en/latest/)
+
 ### TensorFlow Java
 - **Badge:** Training
 - **Description:** Java bindings for TensorFlow, maintained by the TensorFlow JVM SIG. Train and deploy TF models entirely in Java. Available as an optional Tribuo integration. Suitable for teams that want to stay within the JVM ecosystem while using TensorFlow's model formats.
@@ -656,6 +661,15 @@ Notes:
 - **Photo:** https://avatars.githubusercontent.com/u/193434?v=4
 - **Role:** NYJavaSIG founder, AI 4 Java educator, JSR 381 co-author
 - **Links:** [@frankgreco](https://twitter.com/frankgreco) · [Bluesky](https://bsky.app/profile/frankgreco.bsky.social) · [GitHub](https://github.com/fgreco55) · [LinkedIn](https://www.linkedin.com/in/frankdgreco/) · [Website](https://ai4java.com)
+
+### Ivar Grimstad
+
+- **Badge:** Person
+- **Java Champion**
+- **Initials:** IG
+- **Photo:** https://avatars.githubusercontent.com/u/149188?v=4
+- **Role:** Jakarta EE Developer Advocate — Eclipse Foundation; speaks on bringing AI to Jakarta EE (Jakarta Agentic AI)
+- **Links:** [@ivar_grimstad](https://twitter.com/ivar_grimstad) · [Bluesky](https://bsky.app/profile/theguywiththeduketattoo.com) · [GitHub](https://github.com/ivargrimstad) · [LinkedIn](https://www.linkedin.com/in/ivargrimstad/) · [Website](https://www.agilejava.eu)
 
 ### Rod Johnson
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -86,6 +86,7 @@ Questions and answers:
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
+- https://foojay.io/today/how-to-create-a-spring-boot-fraud-scoring-service/
 - https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/
 - https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54
 - https://inside.java/2026/07/25/design-java-mcp-tool/
@@ -755,6 +756,15 @@ Notes:
 - **Role:** Creator of Tools4AI
 - **Links:** [GitHub](https://github.com/vishalmysore) · [LinkedIn](https://www.linkedin.com/in/vishalrow/) · [Blog](https://medium.com/@visrow)
 
+### Daniel Oh
+
+- **Badge:** Person
+- **Java Champion**
+- **Initials:** DO
+- **Photo:** https://avatars.githubusercontent.com/u/14066977?v=4
+- **Role:** Senior Principal Developer Advocate — Red Hat; CNCF Ambassador speaking on agentic AI and cloud-native Java
+- **Links:** [@danieloh30](https://twitter.com/danieloh30) · [Bluesky](https://bsky.app/profile/danieloh30.bsky.social) · [LinkedIn](https://www.linkedin.com/in/daniel-oh-083818112/)
+
 ### Konstantin Pavlov
 
 - **Badge:** Person
@@ -762,6 +772,14 @@ Notes:
 - **Photo:** https://avatars.githubusercontent.com/u/1517853?v=4
 - **Role:** Creator of Tachyon; maintainer of mokksy.dev and LangChain4j Kotlin extensions
 - **Links:** [Bluesky](https://bsky.app/profile/kpavlov.me) · [GitHub](https://github.com/kpavlov) · [Blog](https://kpavlov.me)
+
+### Susanne Pieterse
+
+- **Badge:** Person
+- **Initials:** SP
+- **Photo:** https://avatars.githubusercontent.com/u/18641509?v=4
+- **Role:** Senior Software Engineer & iSAQB-certified Software Architect — OPEN.nl; LangChain4j contributor teaching Java teams to build reliable AI agents
+- **Links:** [Bluesky](https://bsky.app/profile/susivic.bsky.social) · [GitHub](https://github.com/Sus4nne)
 
 ### Mark Pollack
 

--- a/index.html
+++ b/index.html
@@ -1222,6 +1222,17 @@
       </a>
 
       <div class="card">
+        <span class="card-badge badge-inference">Inference</span>
+        <h3><a href="https://www.tornadovm.org">TornadoVM</a></h3>
+        <p>GPU programming framework for Java &mdash; JIT-compiles Java bytecode into CUDA, OpenCL, and Apple Metal at runtime, running on GPUs and multi-core CPUs. Powers GPULlama3.java's GPU acceleration. v5.2.0 added AI-focused kernels: native FP8 conversion, FP8/BF16 tensor-core matrix multiply, cuBLAS/CUTLASS-compatible BFloat16 arrays, and batched FP16 GEMM. From the University of Manchester's Beehive Lab.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://www.tornadovm.org" title="Website"></a>
+          <a class="icon icon-github" href="https://github.com/beehive-lab/TornadoVM" title="GitHub"></a>
+          <a class="icon icon-web" href="https://tornadovm.readthedocs.io/en/latest/" title="Docs"></a>
+        </div>
+      </div>
+
+      <div class="card">
         <span class="card-badge badge-framework">Training</span>
         <h3><a href="https://www.tensorflow.org/jvm">TensorFlow Java</a></h3>
         <p>Java bindings for TensorFlow, maintained by the TensorFlow JVM SIG. Train and deploy TF models entirely in Java. Available as an optional Tribuo integration. Suitable for teams that want to stay within the JVM ecosystem while using TensorFlow's model formats.</p>
@@ -1422,6 +1433,22 @@
             <a class="icon icon-github" href="https://github.com/fgreco55" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://www.linkedin.com/in/frankdgreco/" title="LinkedIn"></a>
             <a class="icon icon-web" href="https://ai4java.com" title="Website"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/149188?v=4" alt="Ivar Grimstad"></div>
+        <div class="person-info">
+          <h4>Ivar Grimstad</h4>
+          <span class="badge-champion">Java Champion</span>
+          <p>Jakarta EE Developer Advocate &mdash; Eclipse Foundation; speaks on bringing AI to Jakarta EE (Jakarta Agentic AI)</p>
+          <div class="person-links">
+            <a class="icon icon-x" href="https://twitter.com/ivar_grimstad" title="@ivar_grimstad"></a>
+            <a class="icon icon-bluesky" href="https://bsky.app/profile/theguywiththeduketattoo.com" title="Bluesky"></a>
+            <a class="icon icon-github" href="https://github.com/ivargrimstad" title="GitHub"></a>
+            <a class="icon icon-linkedin" href="https://www.linkedin.com/in/ivargrimstad/" title="LinkedIn"></a>
+            <a class="icon icon-web" href="https://www.agilejava.eu" title="Website"></a>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -399,6 +399,7 @@
     <div class="news-bar">
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Headlines</h2>
       <ul>
+        <li><a href="https://foojay.io/today/how-to-create-a-spring-boot-fraud-scoring-service/">How to Create a Spring Boot Fraud Scoring Service</a> &mdash; builds a production credit-card fraud detection REST API with Spring Boot and the pure-Java Deep Netts deep-learning library, embedding the model directly in the app instead of a separate Python inference server</li>
         <li><a href="https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/">Connecting Java Reinforcement Learning to Python Gymnasium</a> &mdash; bridges Java RL code to Python's Gymnasium library via JavaCPP, covering Python lifecycle management and NumPy data transfer, starting with CartPole before scaling up to CARLA</li>
         <li><a href="https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54">When Prompts Become Plugins: Generating User Extensions with Graal Script Agent</a> &mdash; introduces a library for turning end-user prompts into sandboxed, reusable JavaScript or Python extensions that run locally within application-defined boundaries</li>
         <li><a href="https://inside.java/2026/07/25/design-java-mcp-tool/">Pairing In-Process and Hosted Embeddings for Java MCP Tool Development</a> &mdash; designing an MCP server on Helidon that supports both local (DJL/MiniLM) and hosted (OpenAI) embedding models behind a stable tool interface</li>
@@ -1601,6 +1602,20 @@
       </div>
 
       <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/14066977?v=4" alt="Daniel Oh"></div>
+        <div class="person-info">
+          <h4>Daniel Oh</h4>
+          <span class="badge-champion">Java Champion</span>
+          <p>Senior Principal Developer Advocate &mdash; Red Hat; CNCF Ambassador speaking on agentic AI and cloud-native Java</p>
+          <div class="person-links">
+            <a class="icon icon-x" href="https://twitter.com/danieloh30" title="@danieloh30"></a>
+            <a class="icon icon-bluesky" href="https://bsky.app/profile/danieloh30.bsky.social" title="Bluesky"></a>
+            <a class="icon icon-linkedin" href="https://www.linkedin.com/in/daniel-oh-083818112/" title="LinkedIn"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/1517853?v=4" alt="Konstantin Pavlov"></div>
         <div class="person-info">
           <h4>Konstantin Pavlov</h4>
@@ -1609,6 +1624,18 @@
             <a class="icon icon-bluesky" href="https://bsky.app/profile/kpavlov.me" title="Bluesky"></a>
             <a class="icon icon-github" href="https://github.com/kpavlov" title="GitHub"></a>
             <a class="icon icon-web" href="https://kpavlov.me" title="Blog"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/18641509?v=4" alt="Susanne Pieterse"></div>
+        <div class="person-info">
+          <h4>Susanne Pieterse</h4>
+          <p>Senior Software Engineer &amp; iSAQB-certified Software Architect &mdash; OPEN.nl; LangChain4j contributor teaching Java teams to build reliable AI agents</p>
+          <div class="person-links">
+            <a class="icon icon-bluesky" href="https://bsky.app/profile/susivic.bsky.social" title="Bluesky"></a>
+            <a class="icon icon-github" href="https://github.com/Sus4nne" title="GitHub"></a>
           </div>
         </div>
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-01</lastmod>
+    <lastmod>2026-08-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-07-31</lastmod>
+    <lastmod>2026-08-01</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Add **TornadoVM** as its own card in Inference & Training. It's already referenced as GPULlama3.java's GPU backend, but its v5.2.0-jdk21 release (already in the News feed) adds AI-specific kernels directly (FP8/BF16 tensor-core matmul, cuBLAS/CUTLASS-compatible BFloat16 arrays, batched FP16 GEMM) — enough to warrant standalone billing per CONTRIBUTING.md's relevance bar.
- Add **Ivar Grimstad** (Java Champion, Jakarta EE Developer Advocate at the Eclipse Foundation) to People to Follow — he actively speaks on bringing AI to Jakarta EE, complementing the existing Jakarta Agentic AI entry.
- Add a News item for [How to Create a Spring Boot Fraud Scoring Service](https://foojay.io/today/how-to-create-a-spring-boot-fraud-scoring-service/) (foojay.io, Jul 31 2026) — a tutorial embedding a pure-Java Deep Netts model directly in a Spring Boot app instead of a separate Python inference server.
- Add **Daniel Oh** (Java Champion, Senior Principal Developer Advocate at Red Hat) — CNCF Ambassador actively speaking on agentic AI and cloud-native Java, including a JavaOne 2026 session on Java agent patterns and MCP.
- Add **Susanne Pieterse** (Senior Software Engineer & iSAQB-certified Software Architect at OPEN.nl) — LangChain4j contributor running hands-on workshops teaching Java teams to build reliable AI agents (evaluation, guardrails, observability), speaking at JavaOne 2026.
- Verified every current News item against the "no older than 3 months" rule — all are within the window, so no pruning this round.
- Considered but did **not** add:
  - "Erupt" (from open PR #60) — legitimate, actively maintained project, but its core identity is a low-code admin/CRUD generator with AI as a secondary module, and the PR overstates its LLM-provider count, so it doesn't fit cleanly alongside the AI-first frameworks in that section.
  - **Arconia** (Thomas Vitale's Spring Boot devex toolkit) — has an AI-specific Docling document-processing pipeline and pluggable AI-observability conventions, but AI is one feature among several general observability/multitenancy features, not the project's core identity.
  - **Vectors** (integrallis/vectors, embedded Java vector-search library with a Spring AI `VectorStore` adapter) — genuinely Java/JVM AI-specific and just announced on Spring's official blog, but only 9 GitHub stars and unproven adoption; too early to clear the site's relevance bar.
  - **Deep Netts** itself as a standalone Inference & Training entry — only 13 commits and no signs of recent maintenance despite the fresh tutorial coverage; the tutorial is newsworthy, the library isn't yet established enough to list.

## Test plan
- [x] `SPEC.md` updated first, then `index.html` regenerated to match (per `AGENTS.md`)
- [x] `sitemap.xml` `<lastmod>` bumped
- [x] Verified all new facts (avatars, roles, socials, article contents) via direct fetch, not inferred from URLs
- [x] Confirmed avatar image URLs return 200
- [ ] Visual check of the rendered page (no build step / local server available in this session)