### PR TITLE
Add Jakarta Agentic AI milestone news, Google ADK for Kotlin, LLM4S, and Julien Dubois

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -86,6 +86,8 @@ Questions and answers:
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
+- https://www.infoq.com/news/2026/08/java-news-roundup-jul27-2026/
+- https://github.com/jakartaee/agentic-ai/releases/tag/1.0.0-M1
 - https://foojay.io/today/how-to-create-a-spring-boot-fraud-scoring-service/
 - https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/
 - https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54
@@ -388,6 +390,16 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** Official Apache Camel components that let Camel routes call any LangChain4j-supported LLM. The chat component (since Camel 4.5) covers single, prompted, and multi-turn LLM calls with RAG enrichment; the agent component (since Camel 4.14) adds stateful/stateless AI agents that can invoke Camel routes as tools (via `ai-tool`) plus MCP client integration. Producer-only endpoints (`langchain4j-chat:id`, `langchain4j-agent:id`) fit naturally into existing integration pipelines.
 - **Links:** [Chat Component Docs](https://camel.apache.org/components/next/langchain4j-chat-component.html) · [Agent Component Docs](https://camel.apache.org/components/next/langchain4j-agent-component.html) · [GitHub](https://github.com/apache/camel)
 
+### Google ADK for Kotlin
+- **Badge:** Framework
+- **Description:** Google's official Kotlin port of the Agent Development Kit — code-first orchestration of tools, agents, and multi-agent hierarchies in Kotlin, with an included dev UI for testing and evaluation. A companion Android flavor adds on-device agent support (Gemini Nano) with cloud fallback.
+- **Links:** [Docs](https://adk.dev/) · [GitHub](https://github.com/google/adk-kotlin) · [Announcement](https://developers.googleblog.com/adk-kotlin-android-building-ai-agents/)
+
+### LLM4S
+- **Badge:** Framework
+- **Description:** Scala 3 framework for building LLM applications — multi-provider support (OpenAI, Anthropic, Azure OpenAI, Gemini, DeepSeek, Cohere, Mistral, OpenRouter, Ollama), an agent framework with tool calling via ScalaMeta, RAG/vector stores, multimodal input, and OpenTelemetry/Langfuse tracing. Broader in scope than the site's other Scala entries (kyo-ai, zio-bedrock-converse) — closer to a "LangChain4j for Scala." Pre-1.0, MIT licensed, active development with weekly community dev-hours.
+- **Links:** [Website](https://llm4s.org/) · [GitHub](https://github.com/llm4s/llm4s)
+
 ---
 
 ## Java with Code Assistants
@@ -626,6 +638,15 @@ Notes:
 - **Photo:** https://avatars.githubusercontent.com/u/141109?v=4
 - **Role:** Spring Framework core committer, Spring AI/MCP integration — Broadcom
 - **Links:** [@sdeleuze](https://x.com/sdeleuze) · [Bluesky](https://bsky.app/profile/seb.deleuze.fr) · [GitHub](https://github.com/sdeleuze) · [LinkedIn](https://www.linkedin.com/in/deleuze) · [Blog](https://seb.deleuze.fr)
+
+### Julien Dubois
+
+- **Badge:** Person
+- **Java Champion**
+- **Initials:** JD
+- **Photo:** https://avatars.githubusercontent.com/u/316835?v=4
+- **Role:** Creator of JHipster; leads a Developer Relations team at Microsoft focused on agentic developer tools for Java/Spring Boot
+- **Links:** [@juliendubois](https://twitter.com/juliendubois) · [Bluesky](https://bsky.app/profile/jdubois.bsky.social) · [GitHub](https://github.com/jdubois) · [LinkedIn](https://www.linkedin.com/in/juliendubois/) · [Website](https://www.julien-dubois.com/)
 
 ### Markus Eisele
 

--- a/index.html
+++ b/index.html
@@ -108,7 +108,9 @@
       {"@type": "ListItem", "position": 51, "name": "Qdrant Java Client", "url": "https://github.com/qdrant/java-client"},
       {"@type": "ListItem", "position": 52, "name": "Weaviate Java Client", "url": "https://github.com/weaviate/java-client"},
       {"@type": "ListItem", "position": 53, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"},
-      {"@type": "ListItem", "position": 54, "name": "Camel LangChain4j Components", "url": "https://camel.apache.org/components/next/langchain4j-chat-component.html"}
+      {"@type": "ListItem", "position": 54, "name": "Camel LangChain4j Components", "url": "https://camel.apache.org/components/next/langchain4j-chat-component.html"},
+      {"@type": "ListItem", "position": 55, "name": "Google ADK for Kotlin", "url": "https://adk.dev/"},
+      {"@type": "ListItem", "position": 56, "name": "LLM4S", "url": "https://llm4s.org/"}
     ]
   }
   </script>
@@ -399,6 +401,8 @@
     <div class="news-bar">
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Headlines</h2>
       <ul>
+        <li><a href="https://www.infoq.com/news/2026/08/java-news-roundup-jul27-2026/">InfoQ Java News Roundup</a> &mdash; weekly Java ecosystem roundup covering two new JDK 28 JEPs, Jakarta Agentic AI's first milestone release, GPULlama3.java 1.0.0 GA, GraalVM 25.2's new Graal Script Agent, and point releases across Micronaut, Quarkus, and JobRunr</li>
+        <li><a href="https://github.com/jakartaee/agentic-ai/releases/tag/1.0.0-M1">Jakarta Agentic AI 1.0.0-M1</a> &mdash; first milestone release of the new Jakarta EE agentic AI specification, adding TCK behavioral-test infrastructure and module/javadoc improvements ahead of 1.0</li>
         <li><a href="https://foojay.io/today/how-to-create-a-spring-boot-fraud-scoring-service/">How to Create a Spring Boot Fraud Scoring Service</a> &mdash; builds a production credit-card fraud detection REST API with Spring Boot and the pure-Java Deep Netts deep-learning library, embedding the model directly in the app instead of a separate Python inference server</li>
         <li><a href="https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/">Connecting Java Reinforcement Learning to Python Gymnasium</a> &mdash; bridges Java RL code to Python's Gymnasium library via JavaCPP, covering Python lifecycle management and NumPy data transfer, starting with CartPole before scaling up to CARLA</li>
         <li><a href="https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54">When Prompts Become Plugins: Generating User Extensions with Graal Script Agent</a> &mdash; introduces a library for turning end-user prompts into sandboxed, reusable JavaScript or Python extensions that run locally within application-defined boundaries</li>
@@ -972,6 +976,27 @@
         </div>
       </div>
 
+      <div class="card">
+        <span class="card-badge badge-framework">Framework</span>
+        <h3><a href="https://adk.dev/">Google ADK for Kotlin</a></h3>
+        <p>Google's official Kotlin port of the Agent Development Kit &mdash; code-first orchestration of tools, agents, and multi-agent hierarchies in Kotlin, with an included dev UI for testing and evaluation. A companion Android flavor adds on-device agent support (Gemini Nano) with cloud fallback.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://adk.dev/" title="Docs"></a>
+          <a class="icon icon-github" href="https://github.com/google/adk-kotlin" title="GitHub"></a>
+          <a class="icon icon-web" href="https://developers.googleblog.com/adk-kotlin-android-building-ai-agents/" title="Announcement"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-framework">Framework</span>
+        <h3><a href="https://llm4s.org/">LLM4S</a></h3>
+        <p>Scala 3 framework for building LLM applications &mdash; multi-provider support (OpenAI, Anthropic, Azure OpenAI, Gemini, DeepSeek, Cohere, Mistral, OpenRouter, Ollama), an agent framework with tool calling via ScalaMeta, RAG/vector stores, multimodal input, and OpenTelemetry/Langfuse tracing. Broader in scope than the site's other Scala entries &mdash; closer to a "LangChain4j for Scala." Pre-1.0, MIT licensed, active development with weekly community dev-hours.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://llm4s.org/" title="Website"></a>
+          <a class="icon icon-github" href="https://github.com/llm4s/llm4s" title="GitHub"></a>
+        </div>
+      </div>
+
     </div>
   </div>
 </section>
@@ -1372,6 +1397,22 @@
             <a class="icon icon-github" href="https://github.com/sdeleuze" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://www.linkedin.com/in/deleuze" title="LinkedIn"></a>
             <a class="icon icon-web" href="https://seb.deleuze.fr" title="Blog"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/316835?v=4" alt="Julien Dubois"></div>
+        <div class="person-info">
+          <h4>Julien Dubois</h4>
+          <span class="badge-champion">Java Champion</span>
+          <p>Creator of JHipster; leads a Developer Relations team at Microsoft focused on agentic developer tools for Java/Spring Boot</p>
+          <div class="person-links">
+            <a class="icon icon-x" href="https://twitter.com/juliendubois" title="@juliendubois"></a>
+            <a class="icon icon-bluesky" href="https://bsky.app/profile/jdubois.bsky.social" title="Bluesky"></a>
+            <a class="icon icon-github" href="https://github.com/jdubois" title="GitHub"></a>
+            <a class="icon icon-linkedin" href="https://www.linkedin.com/in/juliendubois/" title="LinkedIn"></a>
+            <a class="icon icon-web" href="https://www.julien-dubois.com/" title="Website"></a>
           </div>
         </div>
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-02</lastmod>
+    <lastmod>2026-08-04</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Routine governance review of the Java AI ecosystem, per `CONTRIBUTING.md`'s inclusion criteria (Java/JVM-specific, >10% relevance, actively maintained).

- **News:** added the InfoQ Java News Roundup (Aug 3) and the Jakarta Agentic AI 1.0.0-M1 milestone release (Jul 30) — both verified by fetching the source pages.
- **Frameworks:** added two entries that fill real language-coverage gaps:
  - [Google ADK for Kotlin](https://github.com/google/adk-kotlin) — Google's official Kotlin port of the Agent Development Kit (Apache 2.0, v0.7.0), alongside the already-listed Java ADK.
  - [LLM4S](https://github.com/llm4s/llm4s) — a broader, actively-developed Scala 3 LLM/agent framework (MIT, 254 stars), closer to "LangChain4j for Scala" than the site's existing narrower Scala entries.
- **People:** added [Julien Dubois](https://github.com/jdubois) (Java Champion, JHipster creator), who now leads a Microsoft DevRel team building agentic developer tools for Java/Spring Boot.
- Bumped `sitemap.xml`'s `<lastmod>`.

Also checked (no action needed): the two oldest existing news items are still within the 3-month window; a spot-check of several less-recently-verified framework entries found no new abandonment to flag.

## Test plan
- [x] Verified all new content by fetching source pages directly (no guessing from URLs), per `AGENTS.md`
- [x] `SPEC.md` updated first, then `index.html` to match, per the site's update process
- [x] Confirmed `<div>` tag balance in `index.html` and validated `sitemap.xml`

---
_Generated by [Claude Code](https://claude.ai/code/session_01E2ek4BM6Ant9qRy9xQ7d2L)_