### PR TITLE
Add Embabel 1.5.0 news, JAFAR MCP server, and two new people

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -86,6 +86,7 @@ Questions and answers:
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
+- https://github.com/embabel/embabel-agent/releases/tag/v1.5.0
 - https://foojay.io/today/introduction-to-retrieval-augmented-generation-with-java-and-mongodb/
 - https://github.com/a2aproject/a2a-java/releases/tag/v1.2.0.Final
 - https://camel.apache.org/blog/2026/08/camel-ai-tools-mcp-422/
@@ -518,6 +519,11 @@ Technologies that supercharge Java development when paired with AI code assistan
 - **Description:** JVM diagnostics tool for analyzing thread dumps and heap data — deadlocks, bottlenecks, virtual-thread pinning — across JDK 1.4–21+. Usable as a standalone Swing GUI, a JConsole/VisualVM plugin, or a headless MCP server for AI tools like Claude and Cursor.
 - **Links:** [GitHub](https://github.com/irockel/tda)
 
+### JAFAR
+- **Badge:** MCP Server
+- **Description:** Fast, modern Java Flight Recorder (JFR) parser for the JVM with typed and untyped parsing APIs, heap-dump analysis, and an interactive analysis shell. Its `jfr-mcp` module exposes JFR analysis as MCP tools, letting AI agents like Claude directly investigate JVM performance recordings. Apache 2.0, early-stage but active.
+- **Links:** [GitHub](https://github.com/btraceio/jafar) · [Blog](https://jbachorik.github.io/posts/jfr-mcp-serve)
+
 ### SolonCode
 - **Badge:** Assistant
 - **Description:** Open-source, provider-agnostic AI coding agent built on the Solon-AI framework, targeting Java 8–26 runtimes. CLI, web, and desktop-IDE interfaces with auto-edit, approval-based execution, and planning agent modes — an open alternative to Claude Code.
@@ -610,6 +616,14 @@ Notes:
 - **Photo:** https://avatars.githubusercontent.com/u/51285?v=4
 - **Role:** Creator of the original Atmosphere Framework, Grizzly, and AsyncHttpClient; now building the new Atmosphere real-time transport layer for Java AI agents
 - **Links:** [@jfarcand](https://twitter.com/jfarcand) · [GitHub](https://github.com/jfarcand) · [LinkedIn](https://www.linkedin.com/in/jfarcand/)
+
+### Jaroslav Bachorik
+
+- **Badge:** Person
+- **Initials:** JB
+- **Photo:** https://avatars.githubusercontent.com/u/738413?v=4
+- **Role:** JVM serviceability engineer — Datadog; creator of BTrace and JAFAR, a modern JFR parser whose `jfr-mcp` module lets AI agents analyze JVM Flight Recorder data directly
+- **Links:** [@BachorikJ](https://twitter.com/BachorikJ) · [GitHub](https://github.com/jbachorik) · [Blog](https://jbachorik.github.io)
 
 ### Zineb Bendhiba
 
@@ -732,6 +746,14 @@ Notes:
 - **Photo:** https://avatars.githubusercontent.com/u/149188?v=4
 - **Role:** Jakarta EE Developer Advocate — Eclipse Foundation; speaks on bringing AI to Jakarta EE (Jakarta Agentic AI)
 - **Links:** [@ivar_grimstad](https://twitter.com/ivar_grimstad) · [Bluesky](https://bsky.app/profile/theguywiththeduketattoo.com) · [GitHub](https://github.com/ivargrimstad) · [LinkedIn](https://www.linkedin.com/in/ivargrimstad/) · [Website](https://www.agilejava.eu)
+
+### Emmanuel Hugonnet
+
+- **Badge:** Person
+- **Initials:** EH
+- **Photo:** https://avatars.githubusercontent.com/u/73053?v=4
+- **Role:** Software Engineer — IBM; WildFly core contributor driving most of the recent AI work across WildFly AI Feature Pack and LangChain4j-CDI
+- **Links:** [@ehsavoie](https://twitter.com/ehsavoie) · [Bluesky](https://bsky.app/profile/ehsavoie.bsky.social) · [GitHub](https://github.com/ehsavoie) · [LinkedIn](https://www.linkedin.com/in/ehsavoie/) · [Website](https://www.ehsavoie.com)
 
 ### Rod Johnson
 

--- a/index.html
+++ b/index.html
@@ -403,6 +403,7 @@
     <div class="news-bar">
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Headlines</h2>
       <ul>
+        <li><a href="https://github.com/embabel/embabel-agent/releases/tag/v1.5.0">Embabel Agent 1.5.0 Released</a> &mdash; migrates to Spring AI 2.0 GA (Spring Boot 4, Jackson 3), adds Alibaba Cloud DashScope model support, RAG chunk-metadata and full-text scoring improvements, and a vendor-neutral streaming tool loop</li>
         <li><a href="https://foojay.io/today/introduction-to-retrieval-augmented-generation-with-java-and-mongodb/">Introduction to Retrieval-Augmented Generation with Java and MongoDB</a> &mdash; tutorial building a JAX-RS/Helidon RAG service with LangChain4j and MongoDB Atlas as a combined vector store and operational database, retrieving context to answer HR policy questions before calling the LLM</li>
         <li><a href="https://github.com/a2aproject/a2a-java/releases/tag/v1.2.0.Final">A2A Java SDK 1.2.0.Final Released</a> &mdash; adds programmatic auth wiring and a TaskStreamLifecycleHook, upgrades to Quarkus 3.37.3, and ships breaking changes: cross-module split-package resolution, <code>TaskState.UNRECOGNIZED</code> renamed to <code>TASK_STATE_UNSPECIFIED</code> per spec, and corrected authorization enforcement on referenced task lookups</li>
         <li><a href="https://camel.apache.org/blog/2026/08/camel-ai-tools-mcp-422/">Camel Routes as AI Tools: Unified Tooling and MCP Server in Camel 4.22</a> &mdash; introduces <code>camel-ai-tool</code>, a unified tool abstraction so a route defined once works with LangChain4j, Spring AI, or OpenAI, and <code>camel-mcp-server</code>, which exposes tagged routes directly as MCP tools</li>
@@ -1192,6 +1193,16 @@
         </div>
       </div>
 
+      <div class="card">
+        <span class="card-badge badge-assistant">MCP Server</span>
+        <h3><a href="https://github.com/btraceio/jafar">JAFAR</a></h3>
+        <p>Fast, modern Java Flight Recorder (JFR) parser for the JVM with typed and untyped parsing APIs, heap-dump analysis, and an interactive analysis shell. Its <code>jfr-mcp</code> module exposes JFR analysis as MCP tools, letting AI agents like Claude directly investigate JVM performance recordings. Apache 2.0, early-stage but active.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/btraceio/jafar" title="GitHub"></a>
+          <a class="icon icon-web" href="https://jbachorik.github.io/posts/jfr-mcp-serve" title="Blog"></a>
+        </div>
+      </div>
+
       <a class="card" href="https://github.com/opensolon/soloncode">
         <span class="card-badge badge-assistant">Assistant</span>
         <h3>SolonCode</h3>
@@ -1349,6 +1360,19 @@
             <a class="icon icon-x" href="https://twitter.com/jfarcand" title="@jfarcand"></a>
             <a class="icon icon-github" href="https://github.com/jfarcand" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://www.linkedin.com/in/jfarcand/" title="LinkedIn"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/738413?v=4" alt="Jaroslav Bachorik"></div>
+        <div class="person-info">
+          <h4>Jaroslav Bachorik</h4>
+          <p>JVM serviceability engineer &mdash; Datadog; creator of BTrace and JAFAR, a modern JFR parser whose <code>jfr-mcp</code> module lets AI agents analyze JVM Flight Recorder data directly</p>
+          <div class="person-links">
+            <a class="icon icon-x" href="https://twitter.com/BachorikJ" title="@BachorikJ"></a>
+            <a class="icon icon-github" href="https://github.com/jbachorik" title="GitHub"></a>
+            <a class="icon icon-web" href="https://jbachorik.github.io" title="Blog"></a>
           </div>
         </div>
       </div>
@@ -1559,6 +1583,21 @@
             <a class="icon icon-github" href="https://github.com/ivargrimstad" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://www.linkedin.com/in/ivargrimstad/" title="LinkedIn"></a>
             <a class="icon icon-web" href="https://www.agilejava.eu" title="Website"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/73053?v=4" alt="Emmanuel Hugonnet"></div>
+        <div class="person-info">
+          <h4>Emmanuel Hugonnet</h4>
+          <p>Software Engineer &mdash; IBM; WildFly core contributor driving most of the recent AI work across WildFly AI Feature Pack and LangChain4j-CDI</p>
+          <div class="person-links">
+            <a class="icon icon-x" href="https://twitter.com/ehsavoie" title="@ehsavoie"></a>
+            <a class="icon icon-bluesky" href="https://bsky.app/profile/ehsavoie.bsky.social" title="Bluesky"></a>
+            <a class="icon icon-github" href="https://github.com/ehsavoie" title="GitHub"></a>
+            <a class="icon icon-linkedin" href="https://www.linkedin.com/in/ehsavoie/" title="LinkedIn"></a>
+            <a class="icon icon-web" href="https://www.ehsavoie.com" title="Website"></a>
           </div>
         </div>
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-11</lastmod>
+    <lastmod>2026-08-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- **News:** Embabel Agent 1.5.0 (Aug 11, 2026) — migrates to Spring AI 2.0 GA (Spring Boot 4, Jackson 3), adds Alibaba Cloud DashScope model support, RAG chunk-metadata/full-text scoring improvements, and a vendor-neutral streaming tool loop.
- **Java with Code Assistants:** Added [JAFAR](https://github.com/btraceio/jafar), a modern Java Flight Recorder (JFR) parser whose `jfr-mcp` module exposes JFR analysis as MCP tools — lets AI agents like Claude directly investigate JVM performance recordings. Apache 2.0, active.
- **People to Follow:** Added Jaroslav Bachorik (JAFAR creator, Datadog) and Emmanuel Hugonnet (IBM, WildFly core contributor driving the WildFly AI Feature Pack and LangChain4j-CDI work).
- Bumped `sitemap.xml` `<lastmod>` to 2026-08-12.

Also researched but deliberately excluded: minor point releases (AgentScope Java v2.0.2) not deemed News-worthy, a couple of new framework candidates (BoxLang AI, TPipe) that didn't clear the site's adoption/fit bar, and an 8-project abandonment check on smaller existing entries — none were stale enough (12+ months) to flag or remove.

`SPEC.md` was updated first per `AGENTS.md`, then mirrored into `index.html`.

## Test plan
- [ ] Visual check of the new News item, JAFAR card, and the two People cards on ai4jvm.com after merge
- [ ] Confirm all new links resolve (GitHub repos, blog posts, social profiles)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pm4YJQYBoRN4cUE12a7zUE)_