### PR TITLE
Add Spring AI Recipe news, MCP JDWP Java, and fix kyo-ai link

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -86,7 +86,9 @@ Questions and answers:
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
+- https://github.com/langchain4j/langchain4j/releases/tag/1.19.0
 - https://thetalkingapp.medium.com/spring-ai-recipe-building-a-graph-based-agentic-workflow-with-langgraph4j-0fbfcce25a57
+- https://inside.java/2026/08/12/java-mcp-migration/
 - https://github.com/embabel/embabel-agent/releases/tag/v1.5.0
 - https://thetalkingapp.medium.com/spring-ai-recipe-filtering-rag-results-with-metadata-bef2f8a7cb72
 - https://foojay.io/today/introduction-to-retrieval-augmented-generation-with-java-and-mongodb/
@@ -97,6 +99,7 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - https://github.com/jakartaee/agentic-ai/releases/tag/1.0.0-M1
 - https://foojay.io/today/how-to-create-a-spring-boot-fraud-scoring-service/
 - https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/
+- https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.1.0
 - https://micronaut.io/2026/07/27/micronaut-framework-5-1-0-release/
 - https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54
 - https://inside.java/2026/07/25/design-java-mcp-tool/
@@ -937,6 +940,15 @@ Notes:
 - **Photo:** https://avatars.githubusercontent.com/u/14850786?v=4
 - **Role:** Developer Advocate at Neo4j
 - **Links:** [@JMHReif](https://twitter.com/JMHReif) · [GitHub](https://github.com/JMHReif) · [LinkedIn](https://www.linkedin.com/in/jmhreif/) · [Website](https://jmhreif.com)
+
+### Victor Rentea
+
+- **Badge:** Person
+- **Java Champion**
+- **Initials:** VR
+- **Photo:** https://avatars.githubusercontent.com/u/12481094?v=4
+- **Role:** Independent trainer and consultant; runs a full-day "Agentic Engineering" workshop covering MCP, context/prompt engineering, and multi-agent orchestration for Java teams, and speaks on AI-augmented engineering at Java conferences
+- **Links:** [@victorrentea](https://x.com/victorrentea) · [GitHub](https://github.com/victorrentea) · [LinkedIn](https://ro.linkedin.com/in/victor-rentea-trainer) · [Website](https://victorrentea.ro/)
 
 ### Baruch Sadogursky
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -86,7 +86,9 @@ Questions and answers:
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
+- https://thetalkingapp.medium.com/spring-ai-recipe-building-a-graph-based-agentic-workflow-with-langgraph4j-0fbfcce25a57
 - https://github.com/embabel/embabel-agent/releases/tag/v1.5.0
+- https://thetalkingapp.medium.com/spring-ai-recipe-filtering-rag-results-with-metadata-bef2f8a7cb72
 - https://foojay.io/today/introduction-to-retrieval-augmented-generation-with-java-and-mongodb/
 - https://github.com/a2aproject/a2a-java/releases/tag/v1.2.0.Final
 - https://camel.apache.org/blog/2026/08/camel-ai-tools-mcp-422/
@@ -348,8 +350,8 @@ Note: Order by date, newest first. Don't show news older than 3 months
 
 ### kyo-ai
 - **Badge:** Framework
-- **Description:** AI modules for Kyo, the Scala 3 algebraic-effects toolkit. Makes an LLM call a typed, composable value — `AI.gen[A]` derives the schema from your result type, drives the tool-call loop, and decodes the reply — with durable, crash-resumable agent runs and MCP support. Early stage and under active development. Apache 2.0.
-- **Links:** [GitHub](https://github.com/getkyo/kyo-ai) · [Website](https://getkyo.io/)
+- **Description:** AI module for Kyo, the Scala 3 algebraic-effects toolkit. Makes an LLM call a typed, composable value — schema derived from your result type, tool-call loop and conversation threading handled automatically, streaming and persistent actor-backed agents included. Multi-provider (OpenAI-compatible, Anthropic). As of Kyo 1.0.0-RC5 (July 2026), `kyo-ai` moved into the main Kyo monorepo alongside a new `kyo-mcp` module for MCP server/client support. Apache 2.0.
+- **Links:** [GitHub](https://github.com/getkyo/kyo/tree/main/kyo-ai) · [Website](https://getkyo.io/)
 
 ### zio-bedrock-converse
 - **Badge:** SDK
@@ -523,6 +525,11 @@ Technologies that supercharge Java development when paired with AI code assistan
 - **Badge:** MCP Server
 - **Description:** Fast, modern Java Flight Recorder (JFR) parser for the JVM with typed and untyped parsing APIs, heap-dump analysis, and an interactive analysis shell. Its `jfr-mcp` module exposes JFR analysis as MCP tools, letting AI agents like Claude directly investigate JVM performance recordings. Apache 2.0, early-stage but active.
 - **Links:** [GitHub](https://github.com/btraceio/jafar) · [Blog](https://jbachorik.github.io/posts/jfr-mcp-serve)
+
+### MCP JDWP Java
+- **Badge:** MCP Server
+- **Description:** MCP server giving AI agents full debugger control over running Java applications via JDWP/JDI — inspect locals, fields, threads, and object graphs; set conditional, deferred, and chained breakpoints; evaluate expressions in suspended frames; and trace execution with non-intrusive logpoints and field watchpoints, all without restarting the JVM. Runs entirely locally over STDIO. Built on Spring Boot and Spring AI MCP. MIT licensed.
+- **Links:** [GitHub](https://github.com/fgforrest/mcp-jdwp-java)
 
 ### SolonCode
 - **Badge:** Assistant

--- a/index.html
+++ b/index.html
@@ -403,7 +403,9 @@
     <div class="news-bar">
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Headlines</h2>
       <ul>
+        <li><a href="https://github.com/langchain4j/langchain4j/releases/tag/1.19.0">LangChain4j 1.19.0 Released</a> &mdash; adds MCP client improvements, Anthropic Batch Chat Model support, a Milvus V2 service update with hybrid search, watsonx.ai Model Gateway support, and Google GenAI thinking support</li>
         <li><a href="https://thetalkingapp.medium.com/spring-ai-recipe-building-a-graph-based-agentic-workflow-with-langgraph4j-0fbfcce25a57">Spring AI Recipe: Building a Graph-Based Agentic Workflow with LangGraph4j</a> &mdash; Craig Walls builds a customer-support workflow with LangGraph4j nodes for classification, billing, and technical support integrated with Spring AI, contrasting LangGraph4j's framework-neutral graphs with Spring AI Alibaba Graph</li>
+        <li><a href="https://inside.java/2026/08/12/java-mcp-migration/">Evolving a Java MCP Server During MCP Specification Upgrades</a> &mdash; Ana-Maria Mihalceanu shows how to adopt the MCP 2026-07-28 spec while staying compatible with older clients, routing new stateless requests through an adapter layer alongside the legacy initialized workflow</li>
         <li><a href="https://github.com/embabel/embabel-agent/releases/tag/v1.5.0">Embabel Agent 1.5.0 Released</a> &mdash; migrates to Spring AI 2.0 GA (Spring Boot 4, Jackson 3), adds Alibaba Cloud DashScope model support, RAG chunk-metadata and full-text scoring improvements, and a vendor-neutral streaming tool loop</li>
         <li><a href="https://thetalkingapp.medium.com/spring-ai-recipe-filtering-rag-results-with-metadata-bef2f8a7cb72">Spring AI Recipe: Filtering RAG Results with Metadata</a> &mdash; Craig Walls shows how attaching metadata to document chunks and filtering vector-store queries with Spring AI's <code>VectorStore</code> and <code>QuestionAnswerAdvisor</code> narrows RAG retrieval before the LLM sees it</li>
         <li><a href="https://foojay.io/today/introduction-to-retrieval-augmented-generation-with-java-and-mongodb/">Introduction to Retrieval-Augmented Generation with Java and MongoDB</a> &mdash; tutorial building a JAX-RS/Helidon RAG service with LangChain4j and MongoDB Atlas as a combined vector store and operational database, retrieving context to answer HR policy questions before calling the LLM</li>
@@ -414,6 +416,7 @@
         <li><a href="https://github.com/jakartaee/agentic-ai/releases/tag/1.0.0-M1">Jakarta Agentic AI 1.0.0-M1</a> &mdash; first milestone release of the new Jakarta EE agentic AI specification, adding TCK behavioral-test infrastructure and module/javadoc improvements ahead of 1.0</li>
         <li><a href="https://foojay.io/today/how-to-create-a-spring-boot-fraud-scoring-service/">How to Create a Spring Boot Fraud Scoring Service</a> &mdash; builds a production credit-card fraud detection REST API with Spring Boot and the pure-Java Deep Netts deep-learning library, embedding the model directly in the app instead of a separate Python inference server</li>
         <li><a href="https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/">Connecting Java Reinforcement Learning to Python Gymnasium</a> &mdash; bridges Java RL code to Python's Gymnasium library via JavaCPP, covering Python lifecycle management and NumPy data transfer, starting with CartPole before scaling up to CARLA</li>
+        <li><a href="https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.1.0">Spring AI AgentCore 2.1.0 Released</a> &mdash; latest release of the Spring Boot integrations for Amazon Bedrock AgentCore, following the 2.0.0 GA</li>
         <li><a href="https://micronaut.io/2026/07/27/micronaut-framework-5-1-0-release/">Micronaut Framework 5.1.0 Released</a> &mdash; Micronaut LangChain4j upgraded to 2.2.0 with Oracle chat-memory auto-configuration, Chroma embedding-store support, bean-resolved AI-service guardrails, and agentic support, alongside a Micronaut MCP update to track the latest MCP Java SDK</li>
         <li><a href="https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54">When Prompts Become Plugins: Generating User Extensions with Graal Script Agent</a> &mdash; introduces a library for turning end-user prompts into sandboxed, reusable JavaScript or Python extensions that run locally within application-defined boundaries</li>
         <li><a href="https://inside.java/2026/07/25/design-java-mcp-tool/">Pairing In-Process and Hosted Embeddings for Java MCP Tool Development</a> &mdash; designing an MCP server on Helidon that supports both local (DJL/MiniLM) and hosted (OpenAI) embedding models behind a stable tool interface</li>
@@ -1907,6 +1910,21 @@
             <a class="icon icon-github" href="https://github.com/JMHReif" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://www.linkedin.com/in/jmhreif/" title="LinkedIn"></a>
             <a class="icon icon-web" href="https://jmhreif.com" title="Website"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/12481094?v=4" alt="Victor Rentea"></div>
+        <div class="person-info">
+          <h4>Victor Rentea</h4>
+          <span class="badge-champion">Java Champion</span>
+          <p>Independent trainer and consultant; runs a full-day &quot;Agentic Engineering&quot; workshop covering MCP, context/prompt engineering, and multi-agent orchestration for Java teams, and speaks on AI-augmented engineering at Java conferences</p>
+          <div class="person-links">
+            <a class="icon icon-x" href="https://x.com/victorrentea" title="@victorrentea"></a>
+            <a class="icon icon-github" href="https://github.com/victorrentea" title="GitHub"></a>
+            <a class="icon icon-linkedin" href="https://ro.linkedin.com/in/victor-rentea-trainer" title="LinkedIn"></a>
+            <a class="icon icon-web" href="https://victorrentea.ro/" title="Website"></a>
           </div>
         </div>
       </div>

--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
       {"@type": "ListItem", "position": 42, "name": "Tiberius", "url": "https://github.com/tiberius-security/tiberius"},
       {"@type": "ListItem", "position": 43, "name": "Ollama4j", "url": "https://github.com/ollama4j/ollama4j"},
       {"@type": "ListItem", "position": 44, "name": "Cohere Java SDK", "url": "https://github.com/cohere-ai/cohere-java"},
-      {"@type": "ListItem", "position": 45, "name": "kyo-ai", "url": "https://github.com/getkyo/kyo-ai"},
+      {"@type": "ListItem", "position": 45, "name": "kyo-ai", "url": "https://github.com/getkyo/kyo/tree/main/kyo-ai"},
       {"@type": "ListItem", "position": 46, "name": "zio-bedrock-converse", "url": "https://github.com/jamesward/zio-bedrock-converse"},
       {"@type": "ListItem", "position": 47, "name": "zio-http-mcp", "url": "https://github.com/jamesward/zio-http-mcp"},
       {"@type": "ListItem", "position": 48, "name": "Tachyon", "url": "https://github.com/kpavlov/tachyon"},
@@ -403,7 +403,9 @@
     <div class="news-bar">
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Headlines</h2>
       <ul>
+        <li><a href="https://thetalkingapp.medium.com/spring-ai-recipe-building-a-graph-based-agentic-workflow-with-langgraph4j-0fbfcce25a57">Spring AI Recipe: Building a Graph-Based Agentic Workflow with LangGraph4j</a> &mdash; Craig Walls builds a customer-support workflow with LangGraph4j nodes for classification, billing, and technical support integrated with Spring AI, contrasting LangGraph4j's framework-neutral graphs with Spring AI Alibaba Graph</li>
         <li><a href="https://github.com/embabel/embabel-agent/releases/tag/v1.5.0">Embabel Agent 1.5.0 Released</a> &mdash; migrates to Spring AI 2.0 GA (Spring Boot 4, Jackson 3), adds Alibaba Cloud DashScope model support, RAG chunk-metadata and full-text scoring improvements, and a vendor-neutral streaming tool loop</li>
+        <li><a href="https://thetalkingapp.medium.com/spring-ai-recipe-filtering-rag-results-with-metadata-bef2f8a7cb72">Spring AI Recipe: Filtering RAG Results with Metadata</a> &mdash; Craig Walls shows how attaching metadata to document chunks and filtering vector-store queries with Spring AI's <code>VectorStore</code> and <code>QuestionAnswerAdvisor</code> narrows RAG retrieval before the LLM sees it</li>
         <li><a href="https://foojay.io/today/introduction-to-retrieval-augmented-generation-with-java-and-mongodb/">Introduction to Retrieval-Augmented Generation with Java and MongoDB</a> &mdash; tutorial building a JAX-RS/Helidon RAG service with LangChain4j and MongoDB Atlas as a combined vector store and operational database, retrieving context to answer HR policy questions before calling the LLM</li>
         <li><a href="https://github.com/a2aproject/a2a-java/releases/tag/v1.2.0.Final">A2A Java SDK 1.2.0.Final Released</a> &mdash; adds programmatic auth wiring and a TaskStreamLifecycleHook, upgrades to Quarkus 3.37.3, and ships breaking changes: cross-module split-package resolution, <code>TaskState.UNRECOGNIZED</code> renamed to <code>TASK_STATE_UNSPECIFIED</code> per spec, and corrected authorization enforcement on referenced task lookups</li>
         <li><a href="https://camel.apache.org/blog/2026/08/camel-ai-tools-mcp-422/">Camel Routes as AI Tools: Unified Tooling and MCP Server in Camel 4.22</a> &mdash; introduces <code>camel-ai-tool</code>, a unified tool abstraction so a route defined once works with LangChain4j, Spring AI, or OpenAI, and <code>camel-mcp-server</code>, which exposes tagged routes directly as MCP tools</li>
@@ -893,10 +895,10 @@
 
       <div class="card">
         <span class="card-badge badge-framework">Framework</span>
-        <h3><a href="https://github.com/getkyo/kyo-ai">kyo-ai</a></h3>
-        <p>AI modules for Kyo, the Scala 3 algebraic-effects toolkit. Makes an LLM call a typed, composable value — <code>AI.gen[A]</code> derives the schema from your result type, drives the tool-call loop, and decodes the reply — with durable, crash-resumable agent runs and MCP support. Early stage and under active development. Apache 2.0.</p>
+        <h3><a href="https://github.com/getkyo/kyo/tree/main/kyo-ai">kyo-ai</a></h3>
+        <p>AI module for Kyo, the Scala 3 algebraic-effects toolkit. Makes an LLM call a typed, composable value — schema derived from your result type, tool-call loop and conversation threading handled automatically, streaming and persistent actor-backed agents included. Multi-provider (OpenAI-compatible, Anthropic). As of Kyo 1.0.0-RC5 (July 2026), <code>kyo-ai</code> moved into the main Kyo monorepo alongside a new <code>kyo-mcp</code> module for MCP server/client support. Apache 2.0.</p>
         <div class="card-links">
-          <a class="icon icon-github" href="https://github.com/getkyo/kyo-ai" title="GitHub"></a>
+          <a class="icon icon-github" href="https://github.com/getkyo/kyo/tree/main/kyo-ai" title="GitHub"></a>
           <a class="icon icon-web" href="https://getkyo.io/" title="Website"></a>
         </div>
       </div>
@@ -1200,6 +1202,15 @@
         <div class="card-links">
           <a class="icon icon-github" href="https://github.com/btraceio/jafar" title="GitHub"></a>
           <a class="icon icon-web" href="https://jbachorik.github.io/posts/jfr-mcp-serve" title="Blog"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-assistant">MCP Server</span>
+        <h3><a href="https://github.com/fgforrest/mcp-jdwp-java">MCP JDWP Java</a></h3>
+        <p>MCP server giving AI agents full debugger control over running Java applications via JDWP/JDI &mdash; inspect locals, fields, threads, and object graphs; set conditional, deferred, and chained breakpoints; evaluate expressions in suspended frames; and trace execution with non-intrusive logpoints and field watchpoints, all without restarting the JVM. Runs entirely locally over STDIO. Built on Spring Boot and Spring AI MCP. MIT licensed.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/fgforrest/mcp-jdwp-java" title="GitHub"></a>
         </div>
       </div>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-12</lastmod>
+    <lastmod>2026-08-14</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Governance review per `CONTRIBUTING.md` — researched recent Java/JVM AI ecosystem activity and made the following verified additions/fixes to `SPEC.md` and `index.html`:

- **News:** added two Craig Walls "Spring AI Recipe" posts (newest-first, both within the 3-month window):
  - [Spring AI Recipe: Building a Graph-Based Agentic Workflow with LangGraph4j](``https://thetalkingapp.medium.com/spring-ai-recipe-building-a-graph-based-agentic-workflow-with-langgraph4j-0fbfcce25a57``)
  - [Spring AI Recipe: Filtering RAG Results with Metadata](https://thetalkingapp.medium.com/spring-ai-recipe-filtering-rag-results-with-metadata-bef2f8a7cb72)
- **Java with Code Assistants:** added [MCP JDWP Java](https://github.com/fgforrest/mcp-jdwp-java), an MCP server exposing JDWP/JDI debugger control (breakpoints, expression evaluation, watchpoints) to AI agents.
- **Fix:** `kyo-ai`'s standalone repo went stale — the module moved into the main `getkyo/kyo` monorepo as of Kyo 1.0.0-RC5 (July 2026), alongside a new `kyo-mcp` module. Updated the link and description (including the JSON-LD `ItemList` entry) to point at the current location rather than removing an actively-developed project.

All items were verified by fetching the source pages directly (per `AGENTS.md`'s "never infer page contents from a URL" rule) before inclusion. `SPEC.md` was updated first, then `index.html` regenerated to match, per the site's spec-driven process.

## Test plan

- [x] Verified `SPEC.md` and `index.html` stay in sync (badge classes, card structure match existing entries)
- [x] Confirmed `index.html` still starts with `<!DOCTYPE html>` and is well-formed
- [x] Verified all new/changed links resolve to the described content via WebFetch


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGxGoBPE1fsbqEfaAM6ShX)_