### PR TITLE
Add Clement Escoffier and Ilayaperumal Gopinathan to People section

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -731,6 +731,15 @@ Notes:
 - **Role:** LangChain4j core team, Sr. Principal Software Engineer at IBM
 - **Links:** [@mariofusco](https://x.com/mariofusco) · [GitHub](https://github.com/mariofusco) · [LinkedIn](https://www.linkedin.com/in/mario-fusco-3467213/)
 
+### Clement Escoffier
+
+- **Badge:** Person
+- **Java Champion**
+- **Initials:** CE
+- **Photo:** https://avatars.githubusercontent.com/u/402301?v=4
+- **Role:** Red Hat Distinguished Engineer, Quarkus co-creator, works on the Quarkus LangChain4j extension
+- **Links:** [GitHub](https://github.com/cescoffier) · [foojay](https://foojay.io/today/author/clement-escoffier/)
+
 ### Antonio Goncalves
 
 - **Badge:** Person
@@ -739,6 +748,14 @@ Notes:
 - **Photo:** https://avatars.githubusercontent.com/u/729277?v=4
 - **Role:** Principal Software Engineer at Microsoft CoreAI, ParisJUG, Devoxx France, Café IA, book author
 - **Links:** [@agoncal](https://twitter.com/agoncal) · [Bluesky](https://bsky.app/profile/agoncal.bsky.social) · [GitHub](https://github.com/agoncal) · [LinkedIn](https://www.linkedin.com/in/agoncal/) · [Blog](https://antoniogoncalves.org)
+
+### Ilayaperumal Gopinathan
+
+- **Badge:** Person
+- **Initials:** IG
+- **Photo:** https://avatars.githubusercontent.com/u/151690?v=4
+- **Role:** Spring AI team, Broadcom; regularly drives Spring AI release announcements
+- **Links:** [GitHub](https://github.com/ilayaperumalg) · [Spring.io](https://spring.io/authors/ilayaperumalg/)
 
 ### Frank Greco
 

--- a/index.html
+++ b/index.html
@@ -1555,6 +1555,19 @@
       </div>
 
       <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/402301?v=4" alt="Clement Escoffier"></div>
+        <div class="person-info">
+          <h4>Clement Escoffier</h4>
+          <span class="badge-champion">Java Champion</span>
+          <p>Red Hat Distinguished Engineer, Quarkus co-creator, works on the Quarkus LangChain4j extension</p>
+          <div class="person-links">
+            <a class="icon icon-github" href="https://github.com/cescoffier" title="GitHub"></a>
+            <a class="icon icon-web" href="https://foojay.io/today/author/clement-escoffier/" title="foojay"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/729277?v=4" alt="Antonio Goncalves"></div>
         <div class="person-info">
           <h4>Antonio Goncalves</h4>
@@ -1566,6 +1579,18 @@
             <a class="icon icon-github" href="https://github.com/agoncal" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://www.linkedin.com/in/agoncal/" title="LinkedIn"></a>
             <a class="icon icon-web" href="https://antoniogoncalves.org" title="Blog"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/151690?v=4" alt="Ilayaperumal Gopinathan"></div>
+        <div class="person-info">
+          <h4>Ilayaperumal Gopinathan</h4>
+          <p>Spring AI team, Broadcom; regularly drives Spring AI release announcements</p>
+          <div class="person-links">
+            <a class="icon icon-github" href="https://github.com/ilayaperumalg" title="GitHub"></a>
+            <a class="icon icon-web" href="https://spring.io/authors/ilayaperumalg/" title="Spring.io"></a>
           </div>
         </div>
       </div>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-16</lastmod>
+    <lastmod>2026-08-17</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

Routine governance-review pass over `SPEC.md`/`index.html` per `CONTRIBUTING.md`. Two new entries were added to the People section, both verified directly (GitHub profile pages, author pages):

- **Clement Escoffier** — Java Champion, Red Hat Distinguished Engineer, Quarkus co-creator, works on the Quarkus LangChain4j extension. Links to his GitHub and foojay author page.
- **Ilayaperumal Gopinathan** — Spring AI team engineer at Broadcom; regularly authors the Spring AI release announcements. Links to his GitHub and Spring.io author page.

Also cross-checked the News section against upstream release pages (LangChain4j, Spring AI, Embabel, A2A Java SDK, AgentScope Java) and recent posts from foojay, javapro.io, quarkus.io, and inside.java — no new items were found beyond what's already listed, so no News changes were needed this cycle. `sitemap.xml` `<lastmod>` was bumped since `index.html` changed.

One candidate considered and rejected: `genkit-ai/genkit-java`, an unofficial, early-stage (1.0.0-SNAPSHOT, ~24 stars) Java port of Google's Genkit — doesn't yet meet the site's relevance/maturity bar.

## Test plan

- [x] Verified new avatar image URLs return HTTP 200
- [x] Confirmed `index.html` still starts with `<!DOCTYPE html>` and person card divs remain balanced (57 `.person` / 57 `.person-avatar`)
- [x] Verified both new people's GitHub profiles and role claims via direct fetch (not inferred from search snippets)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtP9x2LzwjLq9taUzJ2MNE)_