### PR TITLE
Add news, Pinecone Java Client, and fix SEO conformance gaps

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -29,6 +29,7 @@ AI4JVM is a curated guide to the Java AI ecosystem — a single-page website cov
 
 ### Section Introductions
 Each major content section (`<section>`) should have a 1–2 sentence introduction paragraph below its `<h2>` heading. These intro paragraphs provide keyword-rich body text for search engines and context for users. Examples:
+- **News:** "Latest news and releases from across the Java AI ecosystem — new framework versions, MCP updates, and inference engines."
 - **Agent Frameworks & Libraries:** "Open-source frameworks and SDKs for building AI-powered applications on the JVM — from full agent platforms to Model Context Protocol implementations."
 - **Java with Code Assistants:** "Tools that bridge AI coding assistants and the Java ecosystem — MCP servers, skill registries, and IDE integrations."
 - **Inference & Training:** "Run LLM inference, train ML models, and deploy AI workloads directly on the JVM without Python dependencies."
@@ -86,6 +87,10 @@ Questions and answers:
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
+- https://quarkus.io/blog/a2a-java-sdk-1-2-0-final-released/
+- https://github.com/quarkiverse/quarkus-langchain4j/releases/tag/1.13.0
+- https://javapro.io/2026/08/18/devops-patterns-and-java-26-for-on-premises-llm-platforms-in-safety-critical-environments/
+- https://micronaut.io/2026/08/17/micronaut-framework-5-1-1-released/
 - https://javapro.io/2026/08/13/building-ai-driven-java-systems-with-spring-ai-and-java-26/
 - https://github.com/langchain4j/langchain4j/releases/tag/1.19.0
 - https://thetalkingapp.medium.com/spring-ai-recipe-building-a-graph-based-agentic-workflow-with-langgraph4j-0fbfcce25a57
@@ -391,6 +396,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Badge:** Library
 - **Description:** Official Java client for the Weaviate vector database. The v6 line is a from-scratch rewrite for Weaviate ≥1.32, replacing the deprecated v5 client, with a "Tucked Builder" API for data ingestion, semantic search, filtering, and collection management.
 - **Links:** [GitHub](https://github.com/weaviate/java-client) · [Docs](https://docs.weaviate.io/weaviate/client-libraries/java)
+
+### Pinecone Java Client
+- **Badge:** Library
+- **Description:** Official Java client for the Pinecone vector database. Covers index management (serverless, pod-based, BYOC, sparse indexes), collection operations, vector upsert/query/fetch/update/delete, namespace management, and Pinecone's hosted inference API (embeddings, reranking, model listing). Joins the site's other official vector-database clients for Qdrant, Weaviate, and Milvus.
+- **Links:** [GitHub](https://github.com/pinecone-io/pinecone-java-client)
 
 ### Testcontainers Ollama Module
 - **Badge:** Library

--- a/index.html
+++ b/index.html
@@ -19,8 +19,8 @@
   <link rel="apple-touch-icon" href="/favicon-192.png">
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="AI4JVM — Java &amp; JVM AI Ecosystem Guide">
-  <meta property="og:description" content="The curated guide to AI on the JVM — compare agent frameworks, inference engines, code assistants, and find the people and resources shaping the Java AI ecosystem.">
+  <meta property="og:title" content="AI4JVM — Java &amp; JVM AI Ecosystem Guide: Agent Frameworks, Inference Engines &amp; Tools">
+  <meta property="og:description" content="The curated guide to AI on the JVM — Spring AI, LangChain4j, Kotlin AI frameworks, inference engines, and more. Compare Java AI agent frameworks, find learning resources, and follow key people building the Java AI ecosystem.">
   <meta property="og:url" content="https://ai4jvm.com/">
   <meta property="og:site_name" content="AI4JVM">
   <meta property="og:locale" content="en_US">
@@ -30,8 +30,8 @@
   <meta property="og:image:alt" content="AI4JVM — Java &amp; JVM AI Ecosystem Guide">
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="AI4JVM — Java &amp; JVM AI Ecosystem Guide">
-  <meta name="twitter:description" content="The curated guide to AI on the JVM — compare agent frameworks, inference engines, code assistants, and find the people and resources shaping the Java AI ecosystem.">
+  <meta name="twitter:title" content="AI4JVM — Java &amp; JVM AI Ecosystem Guide: Agent Frameworks, Inference Engines &amp; Tools">
+  <meta name="twitter:description" content="The curated guide to AI on the JVM — Spring AI, LangChain4j, Kotlin AI frameworks, inference engines, and more. Compare Java AI agent frameworks, find learning resources, and follow key people building the Java AI ecosystem.">
   <meta name="twitter:image" content="https://ai4jvm.com/og-image.png">
   <!-- Structured Data -->
   <script type="application/ld+json">
@@ -62,7 +62,7 @@
       {"@type": "ListItem", "position": 5, "name": "Quarkus LangChain4j", "url": "https://docs.quarkiverse.io/quarkus-langchain4j/dev/index.html"},
       {"@type": "ListItem", "position": 6, "name": "Helidon LangChain4j", "url": "https://helidon.io/docs/v4/se/ai/langchain4j/langchain4j"},
       {"@type": "ListItem", "position": 7, "name": "Helidon MCP", "url": "https://helidon.io/docs/v4/se/ai/mcp"},
-      {"@type": "ListItem", "position": 8, "name": "Micronaut MCP", "url": "https://github.com/micronaut-projects/micronaut-mcp"},
+      {"@type": "ListItem", "position": 8, "name": "Micronaut MCP", "url": "https://micronaut-projects.github.io/micronaut-mcp/latest/guide/"},
       {"@type": "ListItem", "position": 9, "name": "LangChain4j-CDI", "url": "https://github.com/langchain4j/langchain4j-cdi"},
       {"@type": "ListItem", "position": 10, "name": "LangGraph4j", "url": "https://langgraph4j.github.io/langgraph4j/"},
       {"@type": "ListItem", "position": 11, "name": "Akka Agents", "url": "https://akka.io/akka-agents"},
@@ -89,7 +89,7 @@
       {"@type": "ListItem", "position": 32, "name": "JVector", "url": "https://github.com/datastax/jvector"},
       {"@type": "ListItem", "position": 33, "name": "Milvus Java SDK", "url": "https://github.com/milvus-io/milvus-sdk-java"},
       {"@type": "ListItem", "position": 34, "name": "ClawRunr", "url": "https://github.com/ClawRunr/JavaClaw"},
-      {"@type": "ListItem", "position": 35, "name": "MCP Toolbox Java SDK", "url": "https://github.com/googleapis/mcp-toolbox-sdk-java"},
+      {"@type": "ListItem", "position": 35, "name": "MCP Toolbox Java SDK", "url": "https://mcp-toolbox.dev/documentation/introduction/"},
       {"@type": "ListItem", "position": 36, "name": "Tools4AI", "url": "https://github.com/vishalmysore/Tools4AI"},
       {"@type": "ListItem", "position": 37, "name": "EclipseStore", "url": "https://github.com/eclipse-store/store"},
       {"@type": "ListItem", "position": 38, "name": "OpenAI Java SDK", "url": "https://github.com/openai/openai-java"},
@@ -107,12 +107,13 @@
       {"@type": "ListItem", "position": 50, "name": "AWS SDK for Java v2 — Bedrock", "url": "https://github.com/aws/aws-sdk-java-v2"},
       {"@type": "ListItem", "position": 51, "name": "Qdrant Java Client", "url": "https://github.com/qdrant/java-client"},
       {"@type": "ListItem", "position": 52, "name": "Weaviate Java Client", "url": "https://github.com/weaviate/java-client"},
-      {"@type": "ListItem", "position": 53, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"},
-      {"@type": "ListItem", "position": 54, "name": "Camel LangChain4j Components", "url": "https://camel.apache.org/components/next/langchain4j-chat-component.html"},
-      {"@type": "ListItem", "position": 55, "name": "Google ADK for Kotlin", "url": "https://adk.dev/"},
-      {"@type": "ListItem", "position": 56, "name": "LLM4S", "url": "https://llm4s.org/"},
-      {"@type": "ListItem", "position": 57, "name": "Agents-Flex", "url": "https://github.com/agents-flex/agents-flex"},
-      {"@type": "ListItem", "position": 58, "name": "Spring AI Alibaba", "url": "https://github.com/alibaba/spring-ai-alibaba"}
+      {"@type": "ListItem", "position": 53, "name": "Pinecone Java Client", "url": "https://github.com/pinecone-io/pinecone-java-client"},
+      {"@type": "ListItem", "position": 54, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"},
+      {"@type": "ListItem", "position": 55, "name": "Camel LangChain4j Components", "url": "https://camel.apache.org/components/next/langchain4j-chat-component.html"},
+      {"@type": "ListItem", "position": 56, "name": "Google ADK for Kotlin", "url": "https://adk.dev/"},
+      {"@type": "ListItem", "position": 57, "name": "LLM4S", "url": "https://llm4s.org/"},
+      {"@type": "ListItem", "position": 58, "name": "Agents-Flex", "url": "https://github.com/agents-flex/agents-flex"},
+      {"@type": "ListItem", "position": 59, "name": "Spring AI Alibaba", "url": "https://github.com/alibaba/spring-ai-alibaba"}
     ]
   }
   </script>
@@ -401,8 +402,13 @@
 <section id="news">
   <div class="container">
     <div class="news-bar">
-      <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Headlines</h2>
+      <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Java AI News</h2>
+      <p class="section-subtitle" style="margin-bottom:.75rem;">Latest news and releases from across the Java AI ecosystem &mdash; new framework versions, MCP updates, and inference engines.</p>
       <ul>
+        <li><a href="https://quarkus.io/blog/a2a-java-sdk-1-2-0-final-released/">A2A Java SDK 1.2.0.Final Released</a> &mdash; hardens the authorization model with read-authorization enforcement on referenced task lookups, adds a <code>TaskStreamLifecycleHook</code> SPI for stream lifecycle management, and ships breaking changes including method renames and a <code>TaskState</code> enum change</li>
+        <li><a href="https://github.com/quarkiverse/quarkus-langchain4j/releases/tag/1.13.0">Quarkus LangChain4j 1.13.0 Released</a> &mdash; upgrades to LangChain4j 1.19.0 and the latest MCP client spec, replaces the Qdrant gRPC client with a REST client, adds GPULlama3 tool-calling support, and expands the Dev UI with a Guardrails page and RAG context visibility</li>
+        <li><a href="https://javapro.io/2026/08/18/devops-patterns-and-java-26-for-on-premises-llm-platforms-in-safety-critical-environments/">DevOps Patterns and Java 26 for On-Premises LLM Platforms in Safety-Critical Environments</a> &mdash; Cornelius May covers RAG-on-Kubernetes architecture, Java 26's AOT caching, Vector API, and Structured Concurrency, and treating prompts as versioned, governed code</li>
+        <li><a href="https://micronaut.io/2026/08/17/micronaut-framework-5-1-1-released/">Micronaut Framework 5.1.1 Released</a> &mdash; maintenance release covering Micronaut Core and Micronaut OpenAPI</li>
         <li><a href="https://javapro.io/2026/08/13/building-ai-driven-java-systems-with-spring-ai-and-java-26/">Building AI-Driven Java Systems with Spring AI and Java 26</a> &mdash; treats LLMs as first-class components with explicit responsibilities, leveraging Java 26's Virtual Threads and Structured Concurrency for efficient I/O-bound agentic workflows</li>
         <li><a href="https://github.com/langchain4j/langchain4j/releases/tag/1.19.0">LangChain4j 1.19.0 Released</a> &mdash; adds MCP client improvements, Anthropic Batch Chat Model support, a Milvus V2 service update with hybrid search, watsonx.ai Model Gateway support, and Google GenAI thinking support</li>
         <li><a href="https://thetalkingapp.medium.com/spring-ai-recipe-building-a-graph-based-agentic-workflow-with-langgraph4j-0fbfcce25a57">Spring AI Recipe: Building a Graph-Based Agentic Workflow with LangGraph4j</a> &mdash; Craig Walls builds a customer-support workflow with LangGraph4j nodes for classification, billing, and technical support integrated with Spring AI, contrasting LangGraph4j's framework-neutral graphs with Spring AI Alibaba Graph</li>
@@ -969,6 +975,15 @@
         <div class="card-links">
           <a class="icon icon-github" href="https://github.com/weaviate/java-client" title="GitHub"></a>
           <a class="icon icon-web" href="https://docs.weaviate.io/weaviate/client-libraries/java" title="Docs"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-inference">Library</span>
+        <h3><a href="https://github.com/pinecone-io/pinecone-java-client">Pinecone Java Client</a></h3>
+        <p>Official Java client for the Pinecone vector database. Covers index management (serverless, pod-based, BYOC, sparse indexes), collection operations, vector upsert/query/fetch/update/delete, namespace management, and Pinecone's hosted inference API (embeddings, reranking, model listing). Joins the site's other official vector-database clients for Qdrant, Weaviate, and Milvus.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/pinecone-io/pinecone-java-client" title="GitHub"></a>
         </div>
       </div>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-17</lastmod>
+    <lastmod>2026-08-18</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary

**Content (per `CONTRIBUTING.md` governance criteria)**
- Added 4 News items covering the 2026-08-13 → 2026-08-18 gap, all verified via direct fetch (not inferred from URLs, per `AGENTS.md`): A2A Java SDK 1.2.0.Final, Quarkus LangChain4j 1.13.0, a javapro.io article on-prem LLM platforms with Java 26, and Micronaut Framework 5.1.1.
- Added **Pinecone Java Client** to Agent Frameworks & Libraries — the official Java client for Pinecone, joining the site's existing official vector-database clients (Qdrant, Weaviate, Milvus).
- Spot-checked several existing entries for activity; all remain current, no removals needed this cycle.

**SEO (per the site's own `## SEO` policy in `SPEC.md`)**
- Synced Open Graph / Twitter meta tags with the actual `<title>`/meta description — they had drifted to the hero subtitle text and a shortened title.
- Fixed 2 stale URLs in the `ItemList` JSON-LD (Micronaut MCP, MCP Toolbox Java SDK) that no longer matched the cards' actual primary links.
- Added a News section intro paragraph and a keyword-bearing News heading ("Latest Java AI News"), matching the pattern already used by every other section.
- Bumped `sitemap.xml` `<lastmod>`.

`SPEC.md` was updated first, then `index.html` to match, per the repo's process. HTML parses cleanly; `ItemList` positions are contiguous 1–59 with no duplicates.

## Test plan
- [x] Verified all new News URLs and the Pinecone client claims via direct fetch of the actual pages
- [x] `python3 -m html.parser` sanity parse of `index.html`
- [x] Verified `ItemList` JSON-LD position numbering is contiguous and duplicate-free after the insert/renumber
- [ ] Visual check in a browser (not done in this environment — recommend a quick look at the News section and the new Pinecone card before merging)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcQJD9W5vpVwr6fNxzSEhc)_