### PR TITLE
Add new ecosystem items, improve SEO, agent readiness, and accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,31 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-YF4ZE4J3N5"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-YF4ZE4J3N5');
-  </script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>AI4JVM — Java &amp; JVM AI Ecosystem Guide: Agent Frameworks, Inference Engines &amp; Tools</title>
-  <meta name="description" content="The curated guide to AI on the JVM — Spring AI, LangChain4j, Kotlin AI frameworks, inference engines, and more. Compare Java AI agent frameworks, find learning resources, and follow key people building the Java AI ecosystem.">
+  <title>AI4JVM — Java AI Frameworks, LLM Inference &amp; Tools for the JVM</title>
+  <meta name="description" content="The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.">
+  <meta name="theme-color" content="#0f1117">
   <link rel="canonical" href="https://ai4jvm.com/">
   <link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48">
   <link rel="icon" href="/favicon.svg" type="image/svg+xml">
   <link rel="apple-touch-icon" href="/favicon-192.png">
-  <!-- Plain-text summary of the site for AI agents/LLMs: https://llmstxt.org -->
+  <!-- Plain-text summaries of the site for AI agents/LLMs: https://llmstxt.org -->
   <link rel="alternate" type="text/markdown" href="/llms.txt" title="AI4JVM (llms.txt)">
+  <link rel="alternate" type="text/markdown" href="/llms-full.txt" title="AI4JVM (llms-full.txt)">
   <!-- Speed up loading of GitHub avatar images -->
   <link rel="preconnect" href="https://avatars.githubusercontent.com" crossorigin>
+  <link rel="dns-prefetch" href="https://avatars.githubusercontent.com">
   <link rel="preconnect" href="https://www.googletagmanager.com">
   <!-- Open Graph -->
   <meta property="og:type" content="website">
-  <meta property="og:title" content="AI4JVM — Java &amp; JVM AI Ecosystem Guide: Agent Frameworks, Inference Engines &amp; Tools">
-  <meta property="og:description" content="The curated guide to AI on the JVM — Spring AI, LangChain4j, Kotlin AI frameworks, inference engines, and more. Compare Java AI agent frameworks, find learning resources, and follow key people building the Java AI ecosystem.">
+  <meta property="og:title" content="AI4JVM — Java AI Frameworks, LLM Inference &amp; Tools for the JVM">
+  <meta property="og:description" content="The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.">
   <meta property="og:url" content="https://ai4jvm.com/">
   <meta property="og:site_name" content="AI4JVM">
   <meta property="og:locale" content="en_US">
@@ -35,21 +30,51 @@
   <meta property="og:image:alt" content="AI4JVM — Java &amp; JVM AI Ecosystem Guide">
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="AI4JVM — Java &amp; JVM AI Ecosystem Guide: Agent Frameworks, Inference Engines &amp; Tools">
-  <meta name="twitter:description" content="The curated guide to AI on the JVM — Spring AI, LangChain4j, Kotlin AI frameworks, inference engines, and more. Compare Java AI agent frameworks, find learning resources, and follow key people building the Java AI ecosystem.">
+  <meta name="twitter:title" content="AI4JVM — Java AI Frameworks, LLM Inference &amp; Tools for the JVM">
+  <meta name="twitter:description" content="The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.">
   <meta name="twitter:image" content="https://ai4jvm.com/og-image.png">
   <!-- Structured Data -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "WebSite",
+    "@id": "https://ai4jvm.com/#website",
     "name": "AI4JVM",
+    "alternateName": "AI for the JVM",
     "url": "https://ai4jvm.com/",
+    "inLanguage": "en-US",
     "description": "The curated guide to AI on the JVM — compare agent frameworks, inference engines, code assistants, and find the people and resources shaping the Java AI ecosystem.",
     "publisher": {
       "@type": "Person",
       "name": "James Ward",
       "url": "https://jamesward.com"
+    },
+    "about": [
+      {"@type": "Thing", "name": "Java"},
+      {"@type": "Thing", "name": "Kotlin"},
+      {"@type": "Thing", "name": "Java virtual machine"},
+      {"@type": "Thing", "name": "Artificial intelligence"},
+      {"@type": "Thing", "name": "Large language model"},
+      {"@type": "Thing", "name": "Model Context Protocol"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": "https://ai4jvm.com/#webpage",
+    "url": "https://ai4jvm.com/",
+    "name": "AI4JVM — Java AI Frameworks, LLM Inference & Tools for the JVM",
+    "description": "The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.",
+    "isPartOf": {"@id": "https://ai4jvm.com/#website"},
+    "inLanguage": "en-US",
+    "dateModified": "2026-08-20",
+    "primaryImageOfPage": {
+      "@type": "ImageObject",
+      "url": "https://ai4jvm.com/og-image.png",
+      "width": 1200,
+      "height": 630
     }
   }
   </script>
@@ -68,57 +93,181 @@
       {"@type": "ListItem", "position": 6, "name": "Helidon LangChain4j", "url": "https://helidon.io/docs/v4/se/ai/langchain4j/langchain4j"},
       {"@type": "ListItem", "position": 7, "name": "Helidon MCP", "url": "https://helidon.io/docs/v4/se/ai/mcp"},
       {"@type": "ListItem", "position": 8, "name": "Micronaut MCP", "url": "https://micronaut-projects.github.io/micronaut-mcp/latest/guide/"},
-      {"@type": "ListItem", "position": 9, "name": "LangChain4j-CDI", "url": "https://github.com/langchain4j/langchain4j-cdi"},
-      {"@type": "ListItem", "position": 10, "name": "LangGraph4j", "url": "https://langgraph4j.github.io/langgraph4j/"},
-      {"@type": "ListItem", "position": 11, "name": "Akka Agents", "url": "https://akka.io/akka-agents"},
-      {"@type": "ListItem", "position": 12, "name": "Koog (JetBrains)", "url": "https://www.jetbrains.com/koog/"},
-      {"@type": "ListItem", "position": 13, "name": "Semantic Kernel (Java)", "url": "https://github.com/microsoft/semantic-kernel-java"},
-      {"@type": "ListItem", "position": 14, "name": "JamJet", "url": "https://docs.jamjet.dev"},
-      {"@type": "ListItem", "position": 15, "name": "Spring AI AgentCore SDK", "url": "https://springaicommunity.mintlify.app/projects/incubating/spring-ai-bedrock-agentcore"},
-      {"@type": "ListItem", "position": 16, "name": "MCP Java SDK", "url": "https://modelcontextprotocol.io/sdk/java/mcp-overview"},
-      {"@type": "ListItem", "position": 17, "name": "Anthropic Java SDK", "url": "https://github.com/anthropics/anthropic-sdk-java"},
-      {"@type": "ListItem", "position": 18, "name": "GitHub Copilot SDK for Java", "url": "https://github.github.com/copilot-sdk-java/"},
-      {"@type": "ListItem", "position": 19, "name": "Graal Script Agent", "url": "https://graalvm.github.io/graal-script-agent/latest/"},
-      {"@type": "ListItem", "position": 20, "name": "Tracy (JetBrains)", "url": "https://jetbrains.github.io/tracy/latest"},
-      {"@type": "ListItem", "position": 21, "name": "Docling Java", "url": "https://docling-project.github.io/docling-java/current"},
-      {"@type": "ListItem", "position": 22, "name": "OmniHai", "url": "https://omnihai.org"},
-      {"@type": "ListItem", "position": 23, "name": "ACP Langchain4j bridge", "url": "https://github.com/OsgiliathEnterprise/acp-langgraph-langchain-bridge"},
-      {"@type": "ListItem", "position": 24, "name": "A2A Java SDK", "url": "https://github.com/a2aproject/a2a-java"},
-      {"@type": "ListItem", "position": 25, "name": "A2A Java SDK for Jakarta Servers", "url": "https://github.com/wildfly-extras/a2a-java-sdk-server-jakarta"},
-      {"@type": "ListItem", "position": 26, "name": "WildFly AI Feature Pack", "url": "https://github.com/wildfly-extras/wildfly-ai-feature-pack"},
-      {"@type": "ListItem", "position": 27, "name": "MCP_JAVA Annotations", "url": "https://github.com/mcp-java/java-mcp-annotations"},
-      {"@type": "ListItem", "position": 28, "name": "Atmosphere", "url": "https://atmosphere.github.io/docs/"},
-      {"@type": "ListItem", "position": 29, "name": "Spring AI Agent Utils", "url": "https://springaicommunity.mintlify.app/projects/incubating/spring-ai-agent-utils"},
-      {"@type": "ListItem", "position": 30, "name": "Jakarta Agentic AI", "url": "https://github.com/jakartaee/agentic-ai"},
-      {"@type": "ListItem", "position": 31, "name": "AgentScope Java", "url": "https://java.agentscope.io/"},
-      {"@type": "ListItem", "position": 32, "name": "JVector", "url": "https://github.com/datastax/jvector"},
-      {"@type": "ListItem", "position": 33, "name": "Milvus Java SDK", "url": "https://github.com/milvus-io/milvus-sdk-java"},
-      {"@type": "ListItem", "position": 34, "name": "ClawRunr", "url": "https://github.com/ClawRunr/JavaClaw"},
-      {"@type": "ListItem", "position": 35, "name": "MCP Toolbox Java SDK", "url": "https://mcp-toolbox.dev/documentation/introduction/"},
-      {"@type": "ListItem", "position": 36, "name": "Tools4AI", "url": "https://github.com/vishalmysore/Tools4AI"},
-      {"@type": "ListItem", "position": 37, "name": "EclipseStore", "url": "https://github.com/eclipse-store/store"},
-      {"@type": "ListItem", "position": 38, "name": "OpenAI Java SDK", "url": "https://github.com/openai/openai-java"},
-      {"@type": "ListItem", "position": 39, "name": "Google Gen AI Java SDK", "url": "https://github.com/googleapis/java-genai"},
-      {"@type": "ListItem", "position": 40, "name": "IBM watsonx.ai Java SDK", "url": "https://github.com/IBM/watsonx-ai-java-sdk"},
-      {"@type": "ListItem", "position": 41, "name": "SAP AI SDK for Java", "url": "https://github.com/SAP/ai-sdk-java"},
-      {"@type": "ListItem", "position": 42, "name": "Tiberius", "url": "https://github.com/tiberius-security/tiberius"},
-      {"@type": "ListItem", "position": 43, "name": "Ollama4j", "url": "https://github.com/ollama4j/ollama4j"},
-      {"@type": "ListItem", "position": 44, "name": "Cohere Java SDK", "url": "https://github.com/cohere-ai/cohere-java"},
-      {"@type": "ListItem", "position": 45, "name": "kyo-ai", "url": "https://github.com/getkyo/kyo/tree/main/kyo-ai"},
-      {"@type": "ListItem", "position": 46, "name": "zio-bedrock-converse", "url": "https://github.com/jamesward/zio-bedrock-converse"},
-      {"@type": "ListItem", "position": 47, "name": "zio-http-mcp", "url": "https://github.com/jamesward/zio-http-mcp"},
-      {"@type": "ListItem", "position": 48, "name": "Tachyon", "url": "https://github.com/kpavlov/tachyon"},
-      {"@type": "ListItem", "position": 49, "name": "Solon-AI", "url": "https://github.com/opensolon/solon-ai"},
-      {"@type": "ListItem", "position": 50, "name": "AWS SDK for Java v2 — Bedrock", "url": "https://github.com/aws/aws-sdk-java-v2"},
-      {"@type": "ListItem", "position": 51, "name": "Qdrant Java Client", "url": "https://github.com/qdrant/java-client"},
-      {"@type": "ListItem", "position": 52, "name": "Weaviate Java Client", "url": "https://github.com/weaviate/java-client"},
-      {"@type": "ListItem", "position": 53, "name": "Pinecone Java Client", "url": "https://github.com/pinecone-io/pinecone-java-client"},
-      {"@type": "ListItem", "position": 54, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"},
-      {"@type": "ListItem", "position": 55, "name": "Camel LangChain4j Components", "url": "https://camel.apache.org/components/next/langchain4j-chat-component.html"},
-      {"@type": "ListItem", "position": 56, "name": "Google ADK for Kotlin", "url": "https://adk.dev/"},
-      {"@type": "ListItem", "position": 57, "name": "LLM4S", "url": "https://llm4s.org/"},
-      {"@type": "ListItem", "position": 58, "name": "Agents-Flex", "url": "https://github.com/agents-flex/agents-flex"},
-      {"@type": "ListItem", "position": 59, "name": "Spring AI Alibaba", "url": "https://github.com/alibaba/spring-ai-alibaba"}
+      {"@type": "ListItem", "position": 9, "name": "Micronaut LangChain4j", "url": "https://micronaut-projects.github.io/micronaut-langchain4j/latest/guide/"},
+      {"@type": "ListItem", "position": 10, "name": "LangChain4j-CDI", "url": "https://github.com/langchain4j/langchain4j-cdi"},
+      {"@type": "ListItem", "position": 11, "name": "LangGraph4j", "url": "https://langgraph4j.github.io/langgraph4j/"},
+      {"@type": "ListItem", "position": 12, "name": "Akka Agents", "url": "https://akka.io/akka-agents"},
+      {"@type": "ListItem", "position": 13, "name": "Koog (JetBrains)", "url": "https://www.jetbrains.com/koog/"},
+      {"@type": "ListItem", "position": 14, "name": "Semantic Kernel (Java)", "url": "https://github.com/microsoft/semantic-kernel-java"},
+      {"@type": "ListItem", "position": 15, "name": "JamJet", "url": "https://docs.jamjet.dev"},
+      {"@type": "ListItem", "position": 16, "name": "Spring AI AgentCore SDK", "url": "https://springaicommunity.mintlify.app/projects/incubating/spring-ai-bedrock-agentcore"},
+      {"@type": "ListItem", "position": 17, "name": "MCP Java SDK", "url": "https://modelcontextprotocol.io/sdk/java/mcp-overview"},
+      {"@type": "ListItem", "position": 18, "name": "Anthropic Java SDK", "url": "https://github.com/anthropics/anthropic-sdk-java"},
+      {"@type": "ListItem", "position": 19, "name": "GitHub Copilot SDK for Java", "url": "https://github.github.com/copilot-sdk-java/"},
+      {"@type": "ListItem", "position": 20, "name": "Graal Script Agent", "url": "https://graalvm.github.io/graal-script-agent/latest/"},
+      {"@type": "ListItem", "position": 21, "name": "Tracy (JetBrains)", "url": "https://jetbrains.github.io/tracy/latest"},
+      {"@type": "ListItem", "position": 22, "name": "Docling Java", "url": "https://docling-project.github.io/docling-java/current"},
+      {"@type": "ListItem", "position": 23, "name": "OmniHai", "url": "https://omnihai.org"},
+      {"@type": "ListItem", "position": 24, "name": "ACP Langchain4j bridge", "url": "https://github.com/OsgiliathEnterprise/acp-langgraph-langchain-bridge"},
+      {"@type": "ListItem", "position": 25, "name": "A2A Java SDK", "url": "https://github.com/a2aproject/a2a-java"},
+      {"@type": "ListItem", "position": 26, "name": "A2A Java SDK for Jakarta Servers", "url": "https://github.com/wildfly-extras/a2a-java-sdk-server-jakarta"},
+      {"@type": "ListItem", "position": 27, "name": "WildFly AI Feature Pack", "url": "https://github.com/wildfly-extras/wildfly-ai-feature-pack"},
+      {"@type": "ListItem", "position": 28, "name": "MCP_JAVA Annotations", "url": "https://github.com/mcp-java/java-mcp-annotations"},
+      {"@type": "ListItem", "position": 29, "name": "Atmosphere", "url": "https://atmosphere.github.io/docs/"},
+      {"@type": "ListItem", "position": 30, "name": "Spring AI Agent Utils", "url": "https://springaicommunity.mintlify.app/projects/incubating/spring-ai-agent-utils"},
+      {"@type": "ListItem", "position": 31, "name": "Spring AI A2A", "url": "https://github.com/spring-ai-community/spring-ai-a2a"},
+      {"@type": "ListItem", "position": 32, "name": "Spring AI Session", "url": "https://spring-ai-community.github.io/spring-ai-session/"},
+      {"@type": "ListItem", "position": 33, "name": "Spring AI Playground", "url": "https://github.com/spring-ai-community/spring-ai-playground"},
+      {"@type": "ListItem", "position": 34, "name": "Jakarta Agentic AI", "url": "https://github.com/jakartaee/agentic-ai"},
+      {"@type": "ListItem", "position": 35, "name": "AgentScope Java", "url": "https://java.agentscope.io/"},
+      {"@type": "ListItem", "position": 36, "name": "JVector", "url": "https://github.com/datastax/jvector"},
+      {"@type": "ListItem", "position": 37, "name": "Milvus Java SDK", "url": "https://github.com/milvus-io/milvus-sdk-java"},
+      {"@type": "ListItem", "position": 38, "name": "ClawRunr", "url": "https://github.com/ClawRunr/JavaClaw"},
+      {"@type": "ListItem", "position": 39, "name": "MCP Toolbox Java SDK", "url": "https://mcp-toolbox.dev/documentation/introduction/"},
+      {"@type": "ListItem", "position": 40, "name": "Tools4AI", "url": "https://github.com/vishalmysore/Tools4AI"},
+      {"@type": "ListItem", "position": 41, "name": "EclipseStore", "url": "https://github.com/eclipse-store/store"},
+      {"@type": "ListItem", "position": 42, "name": "OpenAI Java SDK", "url": "https://github.com/openai/openai-java"},
+      {"@type": "ListItem", "position": 43, "name": "Google Gen AI Java SDK", "url": "https://github.com/googleapis/java-genai"},
+      {"@type": "ListItem", "position": 44, "name": "IBM watsonx.ai Java SDK", "url": "https://github.com/IBM/watsonx-ai-java-sdk"},
+      {"@type": "ListItem", "position": 45, "name": "SAP AI SDK for Java", "url": "https://github.com/SAP/ai-sdk-java"},
+      {"@type": "ListItem", "position": 46, "name": "Tiberius", "url": "https://github.com/tiberius-security/tiberius"},
+      {"@type": "ListItem", "position": 47, "name": "Ollama4j", "url": "https://github.com/ollama4j/ollama4j"},
+      {"@type": "ListItem", "position": 48, "name": "Cohere Java SDK", "url": "https://github.com/cohere-ai/cohere-java"},
+      {"@type": "ListItem", "position": 49, "name": "kyo-ai", "url": "https://github.com/getkyo/kyo/tree/main/kyo-ai"},
+      {"@type": "ListItem", "position": 50, "name": "zio-bedrock-converse", "url": "https://github.com/jamesward/zio-bedrock-converse"},
+      {"@type": "ListItem", "position": 51, "name": "zio-http-mcp", "url": "https://github.com/jamesward/zio-http-mcp"},
+      {"@type": "ListItem", "position": 52, "name": "Tachyon", "url": "https://github.com/kpavlov/tachyon"},
+      {"@type": "ListItem", "position": 53, "name": "Solon-AI", "url": "https://github.com/opensolon/solon-ai"},
+      {"@type": "ListItem", "position": 54, "name": "AWS SDK for Java v2 — Bedrock", "url": "https://github.com/aws/aws-sdk-java-v2"},
+      {"@type": "ListItem", "position": 55, "name": "Qdrant Java Client", "url": "https://github.com/qdrant/java-client"},
+      {"@type": "ListItem", "position": 56, "name": "Weaviate Java Client", "url": "https://github.com/weaviate/java-client"},
+      {"@type": "ListItem", "position": 57, "name": "Pinecone Java Client", "url": "https://github.com/pinecone-io/pinecone-java-client"},
+      {"@type": "ListItem", "position": 58, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"},
+      {"@type": "ListItem", "position": 59, "name": "Camel LangChain4j Components", "url": "https://camel.apache.org/components/next/langchain4j-chat-component.html"},
+      {"@type": "ListItem", "position": 60, "name": "Google ADK for Kotlin", "url": "https://adk.dev/"},
+      {"@type": "ListItem", "position": 61, "name": "LLM4S", "url": "https://llm4s.org/"},
+      {"@type": "ListItem", "position": 62, "name": "Agents-Flex", "url": "https://github.com/agents-flex/agents-flex"},
+      {"@type": "ListItem", "position": 63, "name": "Spring AI Alibaba", "url": "https://github.com/alibaba/spring-ai-alibaba"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "name": "Java AI Code Assistant Tools & MCP Servers",
+    "description": "Curated list of MCP servers, skill registries, and IDE integrations bridging AI coding assistants and the Java ecosystem",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "AI-Git-Bot", "url": "https://gitbot.eu/"},
+      {"@type": "ListItem", "position": 2, "name": "Javadocs.dev MCP Server", "url": "https://www.javadocs.dev/"},
+      {"@type": "ListItem", "position": 3, "name": "JetBrains AI", "url": "https://www.jetbrains.com/ai/"},
+      {"@type": "ListItem", "position": 4, "name": "SkillsJars", "url": "https://www.skillsjars.com/"},
+      {"@type": "ListItem", "position": 5, "name": "jvm-skills", "url": "https://jvmskills.com"},
+      {"@type": "ListItem", "position": 6, "name": "Awesome GitHub Copilot", "url": "https://awesome-copilot.github.com/skills/?q=java"},
+      {"@type": "ListItem", "position": 7, "name": "jOOQ MCP Server", "url": "https://jooq-mcp.martinelli.ch/"},
+      {"@type": "ListItem", "position": 8, "name": "Vaadin MCP Server", "url": "https://mcp.vaadin.com/docs/"},
+      {"@type": "ListItem", "position": 9, "name": "Quarkus Agent MCP", "url": "https://quarkus.io/blog/introducing-agent-mcp/"},
+      {"@type": "ListItem", "position": 10, "name": "Open Liberty MCP Server", "url": "https://openliberty.io/blog/2025/10/23/mcp-standalone-blog.html"},
+      {"@type": "ListItem", "position": 11, "name": "Maven Tools MCP", "url": "https://github.com/arvindand/maven-tools-mcp"},
+      {"@type": "ListItem", "position": 12, "name": "JVM Pulse", "url": "https://github.com/brunoborges/jvm-pulse"},
+      {"@type": "ListItem", "position": 13, "name": "IntelliJ IDEA MCP Server", "url": "https://www.jetbrains.com/help/idea/mcp-server.html"},
+      {"@type": "ListItem", "position": 14, "name": "Apache Camel MCP Server", "url": "https://camel.apache.org/blog/2026/02/camel-jbang-mcp/"},
+      {"@type": "ListItem", "position": 15, "name": "Micronaut Fun MCP Server", "url": "https://micronaut.fun/"},
+      {"@type": "ListItem", "position": 16, "name": "Develocity MCP Servers", "url": "https://docs.develocity.ai/2026.1/integrations/mcp-servers/"},
+      {"@type": "ListItem", "position": 17, "name": "AssistAI (Eclipse IDE MCP Server)", "url": "https://marketplace.eclipse.org/content/assistai-eclipse-ide-mcp-server-ai-agents"},
+      {"@type": "ListItem", "position": 18, "name": "SonarQube MCP Server", "url": "https://github.com/SonarSource/sonarqube-mcp-server"},
+      {"@type": "ListItem", "position": 19, "name": "TDA (Thread Dump Analyzer)", "url": "https://github.com/irockel/tda"},
+      {"@type": "ListItem", "position": 20, "name": "JAFAR", "url": "https://github.com/btraceio/jafar"},
+      {"@type": "ListItem", "position": 21, "name": "MCP JDWP Java", "url": "https://github.com/fgforrest/mcp-jdwp-java"},
+      {"@type": "ListItem", "position": 22, "name": "SolonCode", "url": "https://github.com/opensolon/soloncode"},
+      {"@type": "ListItem", "position": 23, "name": "Junie", "url": "https://www.jetbrains.com/help/ai-assistant/junie-agent.html"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "name": "JVM Inference & Training Libraries",
+    "description": "Curated list of libraries for running LLM inference and training ML models directly on the JVM",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "name": "Deliverance", "url": "https://github.com/edwardcapriolo/deliverance"},
+      {"@type": "ListItem", "position": 2, "name": "Jlama", "url": "https://github.com/tjake/Jlama"},
+      {"@type": "ListItem", "position": 3, "name": "Deep Java Library (DJL)", "url": "https://github.com/deepjavalibrary/djl"},
+      {"@type": "ListItem", "position": 4, "name": "ONNX Runtime Java", "url": "https://onnxruntime.ai/docs/get-started/with-java.html"},
+      {"@type": "ListItem", "position": 5, "name": "Tribuo", "url": "https://tribuo.org/"},
+      {"@type": "ListItem", "position": 6, "name": "GPULlama3.java", "url": "https://github.com/beehive-lab/GPULlama3.java"},
+      {"@type": "ListItem", "position": 7, "name": "TornadoVM", "url": "https://www.tornadovm.org"},
+      {"@type": "ListItem", "position": 8, "name": "TensorFlow Java", "url": "https://www.tensorflow.org/jvm"},
+      {"@type": "ListItem", "position": 9, "name": "Eclipse Deeplearning4j (DL4J)", "url": "https://deeplearning4j.konduit.ai/"},
+      {"@type": "ListItem", "position": 10, "name": "Apache OpenNLP", "url": "https://opennlp.apache.org"}
+    ]
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "name": "People to Follow in the Java AI Ecosystem",
+    "description": "Key voices and project leads shaping AI development on the JVM",
+    "itemListElement": [
+      {"@type": "ListItem", "position": 1, "item": {"@type": "Person", "name": "Sandra Ahlgrimm", "url": "https://github.com/sandraahlgrimm"}},
+      {"@type": "ListItem", "position": 2, "item": {"@type": "Person", "name": "Jean-François Arcand", "url": "https://twitter.com/jfarcand"}},
+      {"@type": "ListItem", "position": 3, "item": {"@type": "Person", "name": "Jaroslav Bachorik", "url": "https://twitter.com/BachorikJ"}},
+      {"@type": "ListItem", "position": 4, "item": {"@type": "Person", "name": "Zineb Bendhiba", "url": "https://x.com/ZinebBendhiba"}},
+      {"@type": "ListItem", "position": 5, "item": {"@type": "Person", "name": "Bruno Borges", "url": "https://twitter.com/brunoborges"}},
+      {"@type": "ListItem", "position": 6, "item": {"@type": "Person", "name": "Vadim Briliantov", "url": "https://github.com/Ololoshechkin"}},
+      {"@type": "ListItem", "position": 7, "item": {"@type": "Person", "name": "Holly Cummins", "url": "https://twitter.com/holly_cummins"}},
+      {"@type": "ListItem", "position": 8, "item": {"@type": "Person", "name": "Eric Deandrea", "url": "https://bsky.app/profile/ericdeandrea.dev"}},
+      {"@type": "ListItem", "position": 9, "item": {"@type": "Person", "name": "Ronald Dehuysser", "url": "https://twitter.com/rdehuyss"}},
+      {"@type": "ListItem", "position": 10, "item": {"@type": "Person", "name": "Sébastien Deleuze", "url": "https://x.com/sdeleuze"}},
+      {"@type": "ListItem", "position": 11, "item": {"@type": "Person", "name": "Iryna Dohndorf", "url": "https://github.com/IDohndorf"}},
+      {"@type": "ListItem", "position": 12, "item": {"@type": "Person", "name": "Julien Dubois", "url": "https://twitter.com/juliendubois"}},
+      {"@type": "ListItem", "position": 13, "item": {"@type": "Person", "name": "Markus Eisele", "url": "https://twitter.com/myfear"}},
+      {"@type": "ListItem", "position": 14, "item": {"@type": "Person", "name": "Mario Fusco", "url": "https://x.com/mariofusco"}},
+      {"@type": "ListItem", "position": 15, "item": {"@type": "Person", "name": "Clement Escoffier", "url": "https://github.com/cescoffier"}},
+      {"@type": "ListItem", "position": 16, "item": {"@type": "Person", "name": "Antonio Goncalves", "url": "https://twitter.com/agoncal"}},
+      {"@type": "ListItem", "position": 17, "item": {"@type": "Person", "name": "Ilayaperumal Gopinathan", "url": "https://github.com/ilayaperumalg"}},
+      {"@type": "ListItem", "position": 18, "item": {"@type": "Person", "name": "Frank Greco", "url": "https://twitter.com/frankgreco"}},
+      {"@type": "ListItem", "position": 19, "item": {"@type": "Person", "name": "Ivar Grimstad", "url": "https://twitter.com/ivar_grimstad"}},
+      {"@type": "ListItem", "position": 20, "item": {"@type": "Person", "name": "Emmanuel Hugonnet", "url": "https://twitter.com/ehsavoie"}},
+      {"@type": "ListItem", "position": 21, "item": {"@type": "Person", "name": "Rod Johnson", "url": "https://twitter.com/springrod"}},
+      {"@type": "ListItem", "position": 22, "item": {"@type": "Person", "name": "Daniel Kec", "url": "https://twitter.com/danielkec"}},
+      {"@type": "ListItem", "position": 23, "item": {"@type": "Person", "name": "Kenneth Kousen", "url": "https://twitter.com/kenkousen"}},
+      {"@type": "ListItem", "position": 24, "item": {"@type": "Person", "name": "Guillaume Laforge", "url": "https://twitter.com/glaforge"}},
+      {"@type": "ListItem", "position": 25, "item": {"@type": "Person", "name": "Dmytro Liubarskyi", "url": "https://bsky.app/profile/dmythro.bsky.social"}},
+      {"@type": "ListItem", "position": 26, "item": {"@type": "Person", "name": "Josh Long", "url": "https://twitter.com/starbuxman"}},
+      {"@type": "ListItem", "position": 27, "item": {"@type": "Person", "name": "T. Jake Luciani", "url": "https://twitter.com/tjake"}},
+      {"@type": "ListItem", "position": 28, "item": {"@type": "Person", "name": "Loïc Magnette", "url": "https://x.com/LoMagnette"}},
+      {"@type": "ListItem", "position": 29, "item": {"@type": "Person", "name": "François Martin", "url": "https://x.com/fmartin_"}},
+      {"@type": "ListItem", "position": 30, "item": {"@type": "Person", "name": "Simon Martinelli", "url": "https://twitter.com/simas_ch"}},
+      {"@type": "ListItem", "position": 31, "item": {"@type": "Person", "name": "Ana-Maria Mihalceanu", "url": "https://twitter.com/ammbra1508"}},
+      {"@type": "ListItem", "position": 32, "item": {"@type": "Person", "name": "Vishal Mysore", "url": "https://github.com/vishalmysore"}},
+      {"@type": "ListItem", "position": 33, "item": {"@type": "Person", "name": "Daniel Oh", "url": "https://twitter.com/danieloh30"}},
+      {"@type": "ListItem", "position": 34, "item": {"@type": "Person", "name": "Michalis Papadimitriou", "url": "https://github.com/mikepapadim"}},
+      {"@type": "ListItem", "position": 35, "item": {"@type": "Person", "name": "Konstantin Pavlov", "url": "https://bsky.app/profile/kpavlov.me"}},
+      {"@type": "ListItem", "position": 36, "item": {"@type": "Person", "name": "Susanne Pieterse", "url": "https://bsky.app/profile/susivic.bsky.social"}},
+      {"@type": "ListItem", "position": 37, "item": {"@type": "Person", "name": "Mark Pollack", "url": "https://twitter.com/markpollack"}},
+      {"@type": "ListItem", "position": 38, "item": {"@type": "Person", "name": "Lize Raes", "url": "https://twitter.com/LizeRaes"}},
+      {"@type": "ListItem", "position": 39, "item": {"@type": "Person", "name": "Reza Rahman", "url": "https://github.com/m-reza-rahman"}},
+      {"@type": "ListItem", "position": 40, "item": {"@type": "Person", "name": "K. Siva Prasad Reddy", "url": "https://twitter.com/sivalabs"}},
+      {"@type": "ListItem", "position": 41, "item": {"@type": "Person", "name": "Jennifer Reif", "url": "https://twitter.com/JMHReif"}},
+      {"@type": "ListItem", "position": 42, "item": {"@type": "Person", "name": "Victor Rentea", "url": "https://x.com/victorrentea"}},
+      {"@type": "ListItem", "position": 43, "item": {"@type": "Person", "name": "Baruch Sadogursky", "url": "https://twitter.com/jbaruch"}},
+      {"@type": "ListItem", "position": 44, "item": {"@type": "Person", "name": "Timo Salm", "url": "https://twitter.com/salmto"}},
+      {"@type": "ListItem", "position": 45, "item": {"@type": "Person", "name": "Otavio Santana", "url": "https://twitter.com/otaviojava"}},
+      {"@type": "ListItem", "position": 46, "item": {"@type": "Person", "name": "Oleg Šelajev", "url": "https://twitter.com/shelajev"}},
+      {"@type": "ListItem", "position": 47, "item": {"@type": "Person", "name": "Zoran Sevarac", "url": "https://github.com/sevarac"}},
+      {"@type": "ListItem", "position": 48, "item": {"@type": "Person", "name": "Bartosz Sorrentino", "url": "https://twitter.com/bsorrentinoJ"}},
+      {"@type": "ListItem", "position": 49, "item": {"@type": "Person", "name": "Alex Soto Bueno", "url": "https://twitter.com/alexsotob"}},
+      {"@type": "ListItem", "position": 50, "item": {"@type": "Person", "name": "Venkat Subramaniam", "url": "https://twitter.com/venkat_s"}},
+      {"@type": "ListItem", "position": 51, "item": {"@type": "Person", "name": "Christian Tzolov", "url": "https://twitter.com/christzolov"}},
+      {"@type": "ListItem", "position": 52, "item": {"@type": "Person", "name": "Dan Vega", "url": "https://twitter.com/therealdanvega"}},
+      {"@type": "ListItem", "position": 53, "item": {"@type": "Person", "name": "Dmitry Vinnik", "url": "https://twitter.com/DmitryVinnik"}},
+      {"@type": "ListItem", "position": 54, "item": {"@type": "Person", "name": "Thomas Vitale", "url": "https://x.com/vitalethomas"}},
+      {"@type": "ListItem", "position": 55, "item": {"@type": "Person", "name": "Craig Walls", "url": "https://twitter.com/habuma"}},
+      {"@type": "ListItem", "position": 56, "item": {"@type": "Person", "name": "James Ward", "url": "https://twitter.com/_jamesward"}},
+      {"@type": "ListItem", "position": 57, "item": {"@type": "Person", "name": "Pascal Wilbrink", "url": "https://github.com/pascalwilbrink"}}
     ]
   }
   </script>
@@ -307,7 +456,7 @@
       overflow: hidden;
     }
     .person-avatar img { width: 100%; height: 100%; object-fit: cover; }
-    .person-info h4 { font-size: .95rem; font-weight: 600; color: var(--text-bright); }
+    .person-info h3 { font-size: .95rem; font-weight: 600; color: var(--text-bright); }
     .badge-champion {
       display: inline-block;
       font-size: .55rem;
@@ -379,6 +528,14 @@
       .card-grid, .people-grid, .resource-list { grid-template-columns: 1fr; }
     }
   </style>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-YF4ZE4J3N5"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-YF4ZE4J3N5');
+  </script>
 </head>
 <body>
 <!-- NAV -->
@@ -410,6 +567,7 @@
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Java AI News</h2>
       <p class="section-subtitle" style="margin-bottom:.75rem;">Latest news and releases from across the Java AI ecosystem &mdash; new framework versions, MCP updates, and inference engines.</p>
       <ul>
+        <li><a href="https://github.com/modelcontextprotocol/java-sdk/releases/tag/v2.0.1">MCP Java SDK 2.0.1 Released</a> &mdash; first patch on the 2.0 line: upgrades the conformance suite to 0.1.16 and Spring AI conformance to 2.0.0 GA, bounds HTTP and STDIO server/client reads, and fixes SSE event classification, pagination, and unregistered-handler behavior in stateless servers</li>
         <li><a href="https://quarkus.io/blog/a2a-java-sdk-1-2-0-final-released/">A2A Java SDK 1.2.0.Final Released</a> &mdash; hardens the authorization model with read-authorization enforcement on referenced task lookups, adds a <code>TaskStreamLifecycleHook</code> SPI for stream lifecycle management, and ships breaking changes including method renames and a <code>TaskState</code> enum change</li>
         <li><a href="https://github.com/quarkiverse/quarkus-langchain4j/releases/tag/1.13.0">Quarkus LangChain4j 1.13.0 Released</a> &mdash; upgrades to LangChain4j 1.19.0 and the latest MCP client spec, replaces the Qdrant gRPC client with a REST client, adds GPULlama3 tool-calling support, and expands the Dev UI with a Guardrails page and RAG context visibility</li>
         <li><a href="https://javapro.io/2026/08/18/devops-patterns-and-java-26-for-on-premises-llm-platforms-in-safety-critical-environments/">DevOps Patterns and Java 26 for On-Premises LLM Platforms in Safety-Critical Environments</a> &mdash; Cornelius May covers RAG-on-Kubernetes architecture, Java 26's AOT caching, Vector API, and Structured Concurrency, and treating prompts as versioned, governed code</li>
@@ -426,8 +584,13 @@
         <li><a href="https://github.com/agentscope-ai/agentscope-java/releases/tag/v2.0.1">AgentScope Java 2.0.1 Released</a> &mdash; maintenance release expanding model-provider support (DeepSeek, GLM, Kimi, MiniMax) and hardening Harness subagent/permission handling, plus fixes for memory leaks and streaming tool-arg repair</li>
         <li><a href="https://www.infoq.com/news/2026/08/java-news-roundup-jul27-2026/">InfoQ Java News Roundup</a> &mdash; weekly Java ecosystem roundup covering two new JDK 28 JEPs, Jakarta Agentic AI's first milestone release, GPULlama3.java 1.0.0 GA, GraalVM 25.2's new Graal Script Agent, and point releases across Micronaut, Quarkus, and JobRunr</li>
         <li><a href="https://github.com/jakartaee/agentic-ai/releases/tag/1.0.0-M1">Jakarta Agentic AI 1.0.0-M1</a> &mdash; first milestone release of the new Jakarta EE agentic AI specification, adding TCK behavioral-test infrastructure and module/javadoc improvements ahead of 1.0</li>
+        <li><a href="https://foojay.io/today/jakarta-agentic-ai-hits-its-first-milestone/">Jakarta Agentic AI Hits Its First Milestone</a> &mdash; Dominika Tasarz walks through the 1.0.0-M1 release now on Maven Central: the draft spec's annotation model (<code>@Agent</code>, <code>@Trigger</code>, <code>@Decision</code>, <code>@Action</code>, <code>@Outcome</code>, <code>@HandleException</code>), a new CDI <code>@WorkflowScoped</code> context, and a vendor-neutral <code>LargeLanguageModel</code> facade</li>
         <li><a href="https://foojay.io/today/how-to-create-a-spring-boot-fraud-scoring-service/">How to Create a Spring Boot Fraud Scoring Service</a> &mdash; builds a production credit-card fraud detection REST API with Spring Boot and the pure-Java Deep Netts deep-learning library, embedding the model directly in the app instead of a separate Python inference server</li>
+        <li><a href="https://inside.java/2026/07/30/under-the-hat-empowering-gpu-acceleration-for-java/">Under the HAT: Empowering GPU Acceleration for Java</a> &mdash; Juan Fumero introduces the Heterogeneous Accelerator Toolkit, which uses OpenJDK Project Babylon's code-reflection APIs to translate sections of Java programs into CUDA and OpenCL at runtime, managing generated code and data migration automatically</li>
         <li><a href="https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/">Connecting Java Reinforcement Learning to Python Gymnasium</a> &mdash; bridges Java RL code to Python's Gymnasium library via JavaCPP, covering Python lifecycle management and NumPy data transfer, starting with CartPole before scaling up to CARLA</li>
+        <li><a href="https://github.com/beehive-lab/GPULlama3.java/releases/tag/v1.0.0">GPULlama3.java 1.0.0 Released</a> &mdash; first major release of the GPU-accelerated Java LLM inference engine, now on Maven Central as <code>io.github.beehive-lab:gpu-llama3</code> with auto-activating <code>1.0.0-jdk21</code> and <code>1.0.0-jdk25</code> builds, making TornadoVM-backed GPU inference a plain Maven or Gradle dependency</li>
+        <li><a href="https://github.com/micronaut-projects/micronaut-langchain4j/releases/tag/v2.2.0">Micronaut LangChain4j 2.2.0 Released</a> &mdash; adds LangChain4j agentic support, Chroma embedding-store support, guardrails resolved from Micronaut beans, and evaluation testing to the official Micronaut integration</li>
+        <li><a href="https://blog.jetbrains.com/air/2026/07/what-s-new-air-gets-more-agents-local-models-and-java-kotlin-code-intelligence/">JetBrains Air Adds Java and Kotlin Code Intelligence</a> &mdash; the agent-first tool gains language intelligence powered by the IntelliJ IDEA code engine (Beta) for mixed Java/Kotlin projects &mdash; jump-to-definition, find usages, symbol search, and error highlighting on agent-modified code &mdash; plus local models via Ollama and LM Studio through ACP-compatible agents</li>
         <li><a href="https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.1.0">Spring AI AgentCore 2.1.0 Released</a> &mdash; latest release of the Spring Boot integrations for Amazon Bedrock AgentCore, following the 2.0.0 GA</li>
         <li><a href="https://micronaut.io/2026/07/27/micronaut-framework-5-1-0-release/">Micronaut Framework 5.1.0 Released</a> &mdash; Micronaut LangChain4j upgraded to 2.2.0 with Oracle chat-memory auto-configuration, Chroma embedding-store support, bean-resolved AI-service guardrails, and agentic support, alongside a Micronaut MCP update to track the latest MCP Java SDK</li>
         <li><a href="https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54">When Prompts Become Plugins: Generating User Extensions with Graal Script Agent</a> &mdash; introduces a library for turning end-user prompts into sandboxed, reusable JavaScript or Python extensions that run locally within application-defined boundaries</li>
@@ -446,6 +609,8 @@
         <li><a href="https://javapro.io/2026/07/08/langchain4j-agentic-workflows-from-ai-calls-to-multi-agent-systems-in-java/">LangChain4j Agentic Workflows: From AI Calls to Multi-Agent Systems</a> &mdash; tutorial covering sequential, loop, parallel, and conditional workflow patterns, goal-oriented planning, and supervisor-based multi-agent systems in Java</li>
         <li><a href="https://foojay.io/today/building-ai-systems-with-mongodb-implementing-the-planning-pattern/">Building AI Systems with MongoDB: Implementing the Planning Pattern</a> &mdash; tutorial building a travel-itinerary AI agent with Jakarta EE, Jakarta Data, LangChain4j, and MongoDB using a Reason-Act-Observe planning loop</li>
         <li><a href="https://a2aproject.github.io/a2a-java/posts/a2a-java-sdk-1-1-0-final-released/">A2A Java SDK 1.1.0.Final Released</a> &mdash; first feature release after GA, adding a TaskAuthorizationProvider SPI for per-user task authorization in multi-tenant deployments, plus a new project website</li>
+        <li><a href="https://spring.io/blog/2026/06/23/spring-ai-self-correcting-structured-output">Self-Correcting Structured Output in Spring AI 2.0</a> &mdash; Christian Tzolov shows how <code>validateSchema()</code> detects malformed model output and retries up to three times with the specific validation errors fed back to the model, while <code>useProviderStructuredOutput()</code> enforces the schema natively on OpenAI, Anthropic, and Google GenAI</li>
+        <li><a href="https://spring.io/blog/2026/06/15/spring-ai-composable-tool-calling">Tool Calling in Spring AI 2.0: A Composable, Agentic Architecture</a> &mdash; Christian Tzolov details lifting the tool-execution loop out of each chat model into the advisor chain as a recursive <code>ToolCallingAdvisor</code>, with <code>ToolSearchToolCallingAdvisor</code> progressive tool disclosure cutting tokens 34&ndash;64% across hundreds of tools</li>
         <li><a href="https://quarkus.io/blog/a2a-java-sdk-1-0-0-final-released/">A2A Java SDK Reaches 1.0 GA</a> &mdash; the Agent2Agent Java SDK ships 1.0.0.Final with spec classes converted to Java records, full JSON-RPC/gRPC/REST transport support, and a cross-SDK interop test kit, followed by 1.1.0 adding a <code>TaskAuthorizationProvider</code> SPI for per-user task authorization</li>
         <li><a href="https://spring.io/blog/2026/06/12/spring-ai-2-0-0-GA-available-now">Spring AI 2.0.0 GA Available Now</a> &mdash; built on Spring Boot 4 with Jackson 3 JSON handling and null-safety annotations, tool calling elevated to a composable advisor-chain component for agentic patterns, and Model Context Protocol integration with annotation-driven programming and enterprise security</li>
         <li><a href="https://github.com/modelcontextprotocol/java-sdk/releases/tag/v2.0.0">MCP Java SDK 2.0.0 Reaches GA</a> &mdash; first major version since 1.x, tracking the 2025-11-25 MCP spec with spec-accurate JSON Schema 2020-12 validation, enforced required fields, and SSE transport deprecated in favor of Streamable HTTP</li>
@@ -546,6 +711,16 @@
         <div class="card-links">
           <a class="icon icon-web" href="https://micronaut-projects.github.io/micronaut-mcp/latest/guide/" title="Docs"></a>
           <a class="icon icon-github" href="https://github.com/micronaut-projects/micronaut-mcp" title="GitHub"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-framework">Framework</span>
+        <h3><a href="https://micronaut-projects.github.io/micronaut-langchain4j/latest/guide/">Micronaut LangChain4j</a></h3>
+        <p>Official Micronaut integration for LangChain4j. Compile-time-generated AI services with modules for OpenAI, Anthropic, Azure, Bedrock, Google AI, and Mistral, plus embedding stores for PostgreSQL, Redis, MongoDB, Elasticsearch, Neo4j, Chroma, and Qdrant. Version 2.2.0 adds agentic support, Chroma embedding stores, and guardrails resolved from Micronaut beans.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://micronaut-projects.github.io/micronaut-langchain4j/latest/guide/" title="Docs"></a>
+          <a class="icon icon-github" href="https://github.com/micronaut-projects/micronaut-langchain4j" title="GitHub"></a>
         </div>
       </div>
 
@@ -754,6 +929,34 @@
         <div class="card-links">
           <a class="icon icon-web" href="https://springaicommunity.mintlify.app/projects/incubating/spring-ai-agent-utils" title="Docs"></a>
           <a class="icon icon-github" href="https://github.com/spring-ai-community/spring-ai-agent-utils" title="GitHub"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-assistant">SDK</span>
+        <h3><a href="https://github.com/spring-ai-community/spring-ai-a2a">Spring AI A2A</a></h3>
+        <p>Spring Boot integration for building Agent2Agent (A2A) protocol servers. Auto-configured JSON-RPC endpoints and task lifecycle handling wired to Spring AI's <code>ChatClient</code>, with full <code>@Tool</code> support and multi-agent orchestration. Complements the A2A Java SDK for Spring applications.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/spring-ai-community/spring-ai-a2a" title="GitHub"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-inference">Library</span>
+        <h3><a href="https://spring-ai-community.github.io/spring-ai-session/">Spring AI Session</a></h3>
+        <p>Event-sourced conversation memory for Spring AI. Structured events with identity, timestamps, and session ownership; turn-aware compaction that trims history on turn boundaries; multi-agent branch isolation; keyword search over history; and pluggable in-memory or JDBC repositories via an SPI.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://spring-ai-community.github.io/spring-ai-session/" title="Docs"></a>
+          <a class="icon icon-github" href="https://github.com/spring-ai-community/spring-ai-session" title="GitHub"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-framework">Framework</span>
+        <h3><a href="https://github.com/spring-ai-community/spring-ai-playground">Spring AI Playground</a></h3>
+        <p>Cross-platform desktop app from the Spring AI Community that acts as a local execution layer for AI agent tools. Build, test, and publish MCP tools with a deny-first sandbox, per-tool risk levels, and human-in-the-loop approval for sensitive operations, plus observability dashboards for tokens, cost, traces, and tool execution.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/spring-ai-community/spring-ai-playground" title="GitHub"></a>
         </div>
       </div>
 
@@ -1315,11 +1518,15 @@
         </div>
       </div>
 
-      <a class="card" href="https://www.infoq.com/news/2025/06/gpullama3-java-gpu-llm/">
+      <div class="card">
         <span class="card-badge badge-inference">Inference</span>
-        <h3>GPULlama3.java</h3>
-        <p>Java-native LLM inference with automatic GPU acceleration via TornadoVM. Supports Llama 3, Mistral, Qwen, Phi-3, and IBM Granite models in GGUF format. TornadoVM translates Java bytecode to GPU kernels (OpenCL, PTX, SPIR-V). From the University of Manchester's Beehive Lab.</p>
-      </a>
+        <h3><a href="https://github.com/beehive-lab/GPULlama3.java">GPULlama3.java</a></h3>
+        <p>Java-native LLM inference with automatic GPU acceleration via TornadoVM. Supports Llama 3, Mistral, Qwen, Phi-3, and IBM Granite models in GGUF format. TornadoVM translates Java bytecode to GPU kernels (OpenCL, PTX, SPIR-V). Reached 1.0.0 in July 2026 and is published to Maven Central as <code>io.github.beehive-lab:gpu-llama3</code> with auto-activating JDK 21 and JDK 25 builds. From the University of Manchester's Beehive Lab.</p>
+        <div class="card-links">
+          <a class="icon icon-github" href="https://github.com/beehive-lab/GPULlama3.java" title="GitHub"></a>
+          <a class="icon icon-web" href="https://www.infoq.com/news/2025/06/gpullama3-java-gpu-llm/" title="InfoQ"></a>
+        </div>
+      </div>
 
       <div class="card">
         <span class="card-badge badge-inference">Inference</span>
@@ -1376,7 +1583,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/5214683?v=4&amp;s=96" alt="Sandra Ahlgrimm" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Sandra Ahlgrimm</h4>
+          <h3>Sandra Ahlgrimm</h3>
           <p>Senior Cloud Advocate for Java &mdash; Microsoft/GitHub; focused on GitHub Copilot for Java developers and LangChain4j integrations, co-leads a local JUG, and represents Microsoft on the GraalVM Program Advisory Board</p>
           <div class="person-links">
             <a class="icon icon-github" href="https://github.com/sandraahlgrimm" title="GitHub"></a>
@@ -1388,7 +1595,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/51285?v=4&amp;s=96" alt="Jean-François Arcand" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Jean-Fran&ccedil;ois Arcand</h4>
+          <h3>Jean-Fran&ccedil;ois Arcand</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Creator of the original Atmosphere Framework, Grizzly, and AsyncHttpClient; now building the new Atmosphere real-time transport layer for Java AI agents</p>
           <div class="person-links">
@@ -1402,7 +1609,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/738413?v=4&amp;s=96" alt="Jaroslav Bachorik" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Jaroslav Bachorik</h4>
+          <h3>Jaroslav Bachorik</h3>
           <p>JVM serviceability engineer &mdash; Datadog; creator of BTrace and JAFAR, a modern JFR parser whose <code>jfr-mcp</code> module lets AI agents analyze JVM Flight Recorder data directly</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/BachorikJ" title="@BachorikJ"></a>
@@ -1415,7 +1622,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/12056979?v=4&amp;s=96" alt="Zineb Bendhiba" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Zineb Bendhiba</h4>
+          <h3>Zineb Bendhiba</h3>
           <p>Principal Software Engineer &mdash; IBM; Apache Camel PMC member, maintains Camel Quarkus and Quarkus Qdrant, lead author of Camel 4.22's <code>camel-ai-tool</code> and <code>camel-mcp-server</code></p>
           <div class="person-links">
             <a class="icon icon-x" href="https://x.com/ZinebBendhiba" title="@ZinebBendhiba"></a>
@@ -1430,7 +1637,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/129743?v=4&amp;s=96" alt="Bruno Borges" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Bruno Borges</h4>
+          <h3>Bruno Borges</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Principal Program Manager &mdash; Microsoft Java Engineering Group</p>
           <div class="person-links">
@@ -1446,7 +1653,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/24360128?v=4&amp;s=96" alt="Vadim Briliantov" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Vadim Briliantov</h4>
+          <h3>Vadim Briliantov</h3>
           <p>Technical Lead of Koog / AI Agents Platform &mdash; JetBrains</p>
           <div class="person-links">
             <a class="icon icon-github" href="https://github.com/Ololoshechkin" title="GitHub"></a>
@@ -1459,7 +1666,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/11509290?v=4&amp;s=96" alt="Holly Cummins" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Holly Cummins</h4>
+          <h3>Holly Cummins</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Senior Principal Software Engineer &mdash; IBM Quarkus team</p>
           <div class="person-links">
@@ -1475,7 +1682,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/363447?v=4&amp;s=96" alt="Eric Deandrea" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Eric Deandrea</h4>
+          <h3>Eric Deandrea</h3>
           <span class="badge-champion">Java Champion</span>
           <p><a href="https://docling-project.github.io/docling-java/current">Docling Java</a> project lead, contributor to LangChain4j, Sr. Principal Software Engineer at IBM</p>
           <div class="person-links">
@@ -1490,7 +1697,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/567842?v=4&amp;s=96" alt="Ronald Dehuysser" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Ronald Dehuysser</h4>
+          <h3>Ronald Dehuysser</h3>
           <p>Creator of JobRunr and ClawRunr</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/rdehuyss" title="@rdehuyss"></a>
@@ -1503,7 +1710,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/141109?v=4&amp;s=96" alt="Sébastien Deleuze" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Sébastien Deleuze</h4>
+          <h3>Sébastien Deleuze</h3>
           <p>Spring Framework core committer, Spring AI/MCP integration &mdash; Broadcom</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://x.com/sdeleuze" title="@sdeleuze"></a>
@@ -1518,7 +1725,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/79046580?v=4&amp;s=96" alt="Iryna Dohndorf" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Iryna Dohndorf</h4>
+          <h3>Iryna Dohndorf</h3>
           <p>Creator of Tiberius &mdash; Java security testing framework for LLM applications; software engineer at Karakun; her work sits at the intersection of Java engineering, AI safety, and antifragile system design</p>
           <div class="person-links">
             <a class="icon icon-github" href="https://github.com/IDohndorf" title="GitHub"></a>
@@ -1531,7 +1738,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/316835?v=4&amp;s=96" alt="Julien Dubois" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Julien Dubois</h4>
+          <h3>Julien Dubois</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Creator of JHipster; leads a Developer Relations team at Microsoft focused on agentic developer tools for Java/Spring Boot</p>
           <div class="person-links">
@@ -1547,7 +1754,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/1358554?v=4&amp;s=96" alt="Markus Eisele" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Markus Eisele</h4>
+          <h3>Markus Eisele</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Developer Advocate &mdash; IBM Research, JavaLand founder</p>
           <div class="person-links">
@@ -1563,7 +1770,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/372781?v=4&amp;s=96" alt="Mario Fusco" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Mario Fusco</h4>
+          <h3>Mario Fusco</h3>
           <span class="badge-champion">Java Champion</span>
           <p>LangChain4j core team, Sr. Principal Software Engineer at IBM</p>
           <div class="person-links">
@@ -1577,7 +1784,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/402301?v=4&amp;s=96" alt="Clement Escoffier" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Clement Escoffier</h4>
+          <h3>Clement Escoffier</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Red Hat Distinguished Engineer, Quarkus co-creator, works on the Quarkus LangChain4j extension</p>
           <div class="person-links">
@@ -1590,7 +1797,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/729277?v=4&amp;s=96" alt="Antonio Goncalves" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Antonio Goncalves</h4>
+          <h3>Antonio Goncalves</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Principal Software Engineer at Microsoft CoreAI, ParisJUG, Devoxx France, Caf&eacute; IA, book author</p>
           <div class="person-links">
@@ -1606,7 +1813,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/151690?v=4&amp;s=96" alt="Ilayaperumal Gopinathan" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Ilayaperumal Gopinathan</h4>
+          <h3>Ilayaperumal Gopinathan</h3>
           <p>Spring AI team, Broadcom; regularly drives Spring AI release announcements</p>
           <div class="person-links">
             <a class="icon icon-github" href="https://github.com/ilayaperumalg" title="GitHub"></a>
@@ -1618,7 +1825,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/193434?v=4&amp;s=96" alt="Frank Greco" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Frank Greco</h4>
+          <h3>Frank Greco</h3>
           <span class="badge-champion">Java Champion</span>
           <p>NYJavaSIG founder, AI 4 Java educator, JSR 381 co-author</p>
           <div class="person-links">
@@ -1634,7 +1841,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/149188?v=4&amp;s=96" alt="Ivar Grimstad" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Ivar Grimstad</h4>
+          <h3>Ivar Grimstad</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Jakarta EE Developer Advocate &mdash; Eclipse Foundation; speaks on bringing AI to Jakarta EE (Jakarta Agentic AI)</p>
           <div class="person-links">
@@ -1650,7 +1857,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/73053?v=4&amp;s=96" alt="Emmanuel Hugonnet" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Emmanuel Hugonnet</h4>
+          <h3>Emmanuel Hugonnet</h3>
           <p>Software Engineer &mdash; IBM; WildFly core contributor driving most of the recent AI work across WildFly AI Feature Pack and LangChain4j-CDI</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/ehsavoie" title="@ehsavoie"></a>
@@ -1665,7 +1872,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/1916583?v=4&amp;s=96" alt="Rod Johnson" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Rod Johnson</h4>
+          <h3>Rod Johnson</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Creator of Spring Framework, CEO of Embabel</p>
           <div class="person-links">
@@ -1680,7 +1887,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/1773630?v=4&amp;s=96" alt="Daniel Kec" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Daniel Kec</h4>
+          <h3>Daniel Kec</h3>
           <p>Helidon developer &mdash; Oracle</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/danielkec" title="@danielkec"></a>
@@ -1694,7 +1901,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/22784?v=4&amp;s=96" alt="Kenneth Kousen" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Kenneth Kousen</h4>
+          <h3>Kenneth Kousen</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Author of six books including <em>Kotlin Cookbook</em> and <em>Modern Java Recipes</em>. O&rsquo;Reilly instructor for AI + Java courses. Professor of Practice in Computer Science at Trinity College. President of Kousen IT, Inc.</p>
           <div class="person-links">
@@ -1712,7 +1919,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/47907?v=4&amp;s=96" alt="Guillaume Laforge" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Guillaume Laforge</h4>
+          <h3>Guillaume Laforge</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Google Developer Advocate &mdash; Java, Groovy, AI</p>
           <div class="person-links">
@@ -1728,7 +1935,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/3154404?v=4&amp;s=96" alt="Dmytro Liubarskyi" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Dmytro Liubarskyi</h4>
+          <h3>Dmytro Liubarskyi</h3>
           <p>Creator of LangChain4j, Principal Architect &mdash; IBM</p>
           <div class="person-links">
             <a class="icon icon-bluesky" href="https://bsky.app/profile/dmythro.bsky.social" title="Bluesky"></a>
@@ -1741,7 +1948,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/54473?v=4&amp;s=96" alt="Josh Long" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Josh Long</h4>
+          <h3>Josh Long</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Spring Developer Advocate at Broadcom</p>
           <div class="person-links">
@@ -1757,7 +1964,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/44456?v=4&amp;s=96" alt="T. Jake Luciani" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>T. Jake Luciani</h4>
+          <h3>T. Jake Luciani</h3>
           <p>Creator of Jlama &mdash; Java LLM inference</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/tjake" title="@tjake"></a>
@@ -1770,7 +1977,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/6390187?v=4&amp;s=96" alt="Loïc Magnette" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Loïc Magnette</h4>
+          <h3>Loïc Magnette</h3>
           <p>Senior Software Engineer at Oniryx; BeJUG (Belgian Java User Group) co-organizer, writes and speaks on LangChain4j agentic workflows for Quarkus</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://x.com/LoMagnette" title="@LoMagnette"></a>
@@ -1785,7 +1992,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/14319020?v=4&amp;s=96" alt="François Martin" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>François Martin</h4>
+          <h3>François Martin</h3>
           <p>International speaker and author, Oracle ACE Associate, senior full-stack software engineer</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://x.com/fmartin_" title="@fmartin_"></a>
@@ -1801,7 +2008,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/593352?v=4&amp;s=96" alt="Simon Martinelli" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Simon Martinelli</h4>
+          <h3>Simon Martinelli</h3>
           <p>Creator of AI Unfied Process and the jOOQ MCP Server</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/simas_ch" title="@simas_ch"></a>
@@ -1814,7 +2021,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/9703337?v=4&amp;s=96" alt="Ana-Maria Mihalceanu" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Ana-Maria Mihalceanu</h4>
+          <h3>Ana-Maria Mihalceanu</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Senior Developer Advocate, Java Platform Group at Oracle; writes and speaks on Java MCP tooling and AI, co-founder of the Bucharest Software Craftsmanship Community</p>
           <div class="person-links">
@@ -1828,7 +2035,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/25938717?v=4&amp;s=96" alt="Vishal Mysore" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Vishal Mysore</h4>
+          <h3>Vishal Mysore</h3>
           <p>Creator of Tools4AI</p>
           <div class="person-links">
             <a class="icon icon-github" href="https://github.com/vishalmysore" title="GitHub"></a>
@@ -1841,7 +2048,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/14066977?v=4&amp;s=96" alt="Daniel Oh" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Daniel Oh</h4>
+          <h3>Daniel Oh</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Senior Principal Developer Advocate &mdash; Red Hat; CNCF Ambassador speaking on agentic AI and cloud-native Java</p>
           <div class="person-links">
@@ -1855,7 +2062,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/8652854?v=4&amp;s=96" alt="Michalis Papadimitriou" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Michalis Papadimitriou</h4>
+          <h3>Michalis Papadimitriou</h3>
           <p>Research Fellow, University of Manchester and Senior Software Engineer at Neo4j; TornadoVM core maintainer and lead author of GPULlama3.java, GPU-accelerated LLM inference in pure Java</p>
           <div class="person-links">
             <a class="icon icon-github" href="https://github.com/mikepapadim" title="GitHub"></a>
@@ -1868,7 +2075,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/1517853?v=4&amp;s=96" alt="Konstantin Pavlov" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Konstantin Pavlov</h4>
+          <h3>Konstantin Pavlov</h3>
           <p>Creator of Tachyon; maintainer of mokksy.dev and LangChain4j Kotlin extensions</p>
           <div class="person-links">
             <a class="icon icon-bluesky" href="https://bsky.app/profile/kpavlov.me" title="Bluesky"></a>
@@ -1881,7 +2088,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/18641509?v=4&amp;s=96" alt="Susanne Pieterse" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Susanne Pieterse</h4>
+          <h3>Susanne Pieterse</h3>
           <p>Senior Software Engineer &amp; iSAQB-certified Software Architect &mdash; OPEN.nl; LangChain4j contributor teaching Java teams to build reliable AI agents</p>
           <div class="person-links">
             <a class="icon icon-bluesky" href="https://bsky.app/profile/susivic.bsky.social" title="Bluesky"></a>
@@ -1893,7 +2100,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/247466?v=4&amp;s=96" alt="Mark Pollack" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Mark Pollack</h4>
+          <h3>Mark Pollack</h3>
           <p>Spring AI project lead</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/markpollack" title="@markpollack"></a>
@@ -1906,7 +2113,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/49833622?v=4&amp;s=96" alt="Lize Raes" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Lize Raes</h4>
+          <h3>Lize Raes</h3>
           <p>LangChain4j core team, Developer Advocate at Oracle</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/LizeRaes" title="@LizeRaes"></a>
@@ -1919,7 +2126,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/3622346?v=4&amp;s=96" alt="Reza Rahman" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Reza Rahman</h4>
+          <h3>Reza Rahman</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Jakarta Agentic AI project lead at Payara/Azul, Jakarta EE Ambassadors founder</p>
           <div class="person-links">
@@ -1933,7 +2140,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/542428?v=4&amp;s=96" alt="K. Siva Prasad Reddy" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>K. Siva Prasad Reddy</h4>
+          <h3>K. Siva Prasad Reddy</h3>
           <p>Developer Advocate at JetBrains, author of <em>Beginning Spring Boot 3</em></p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/sivalabs" title="@sivalabs"></a>
@@ -1948,7 +2155,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/14850786?v=4&amp;s=96" alt="Jennifer Reif" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Jennifer Reif</h4>
+          <h3>Jennifer Reif</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Developer Advocate at Neo4j</p>
           <div class="person-links">
@@ -1963,7 +2170,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/12481094?v=4&amp;s=96" alt="Victor Rentea" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Victor Rentea</h4>
+          <h3>Victor Rentea</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Independent trainer and consultant; runs a full-day &quot;Agentic Engineering&quot; workshop covering MCP, context/prompt engineering, and multi-agent orchestration for Java teams, and speaks on AI-augmented engineering at Java conferences</p>
           <div class="person-links">
@@ -1978,7 +2185,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/247332?v=4&amp;s=96" alt="Baruch Sadogursky" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Baruch Sadogursky</h4>
+          <h3>Baruch Sadogursky</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Developer Advocate at Tessl, co-author of <em>Liquid Software</em> and <em>DevOps Tools for Java Developers</em></p>
           <div class="person-links">
@@ -1994,7 +2201,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/52704922?v=4&amp;s=96" alt="Timo Salm" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Timo Salm</h4>
+          <h3>Timo Salm</h3>
           <p>Principal Solutions Engineer, VMware Tanzu at Broadcom; frequent conference speaker comparing Java agentic-AI frameworks (Spring AI, LangChain4j, Embabel)</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/salmto" title="@salmto"></a>
@@ -2007,7 +2214,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/863011?v=4&amp;s=96" alt="Otavio Santana" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Otavio Santana</h4>
+          <h3>Otavio Santana</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Jakarta Data/Jakarta NoSQL spec lead, Eclipse JNoSQL creator, writes on building AI agents with Jakarta EE and LangChain4j</p>
           <div class="person-links">
@@ -2023,7 +2230,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/426039?v=4&amp;s=96" alt="Oleg Šelajev" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Oleg Šelajev</h4>
+          <h3>Oleg Šelajev</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Developer Relations Lead for AI &mdash; Docker</p>
           <div class="person-links">
@@ -2037,7 +2244,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/158153?v=4&amp;s=96" alt="Zoran Sevarac" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Zoran Sevarac</h4>
+          <h3>Zoran Sevarac</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Associate Professor, University of Belgrade; creator of Deep Netts and Neuroph, pure-Java deep learning libraries, and JSR-381 (Visual Recognition API) co-lead</p>
           <div class="person-links">
@@ -2051,7 +2258,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/301596?v=4&amp;s=96" alt="Bartosz Sorrentino" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Bartosz Sorrentino</h4>
+          <h3>Bartosz Sorrentino</h3>
           <p>LangGraph4j creator, Principal Software Architect</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/bsorrentinoJ" title="@bsorrentinoJ"></a>
@@ -2064,7 +2271,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/1517153?v=4&amp;s=96" alt="Alex Soto Bueno" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Alex Soto Bueno</h4>
+          <h3>Alex Soto Bueno</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Director of Developer Experience &mdash; Red Hat, co-author of "AI Agents with Java" (O'Reilly)</p>
           <div class="person-links">
@@ -2078,7 +2285,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/5804?v=4&amp;s=96" alt="Venkat Subramaniam" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Venkat Subramaniam</h4>
+          <h3>Venkat Subramaniam</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Founder of Agile Developer, creator of the dev2next and Arc of AI conferences, award-winning author and instructor at the University of Houston</p>
           <div class="person-links">
@@ -2093,7 +2300,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/1351573?v=4&amp;s=96" alt="Christian Tzolov" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Christian Tzolov</h4>
+          <h3>Christian Tzolov</h3>
           <p>Spring AI lead, MCP Java SDK founder, Spring team at Broadcom</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/christzolov" title="@christzolov"></a>
@@ -2107,7 +2314,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/349507?v=4&amp;s=96" alt="Dan Vega" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Dan Vega</h4>
+          <h3>Dan Vega</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Spring Developer Advocate, YouTube educator</p>
           <div class="person-links">
@@ -2123,7 +2330,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/12485205?v=4&amp;s=96" alt="Dmitry Vinnik" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Dmitry Vinnik</h4>
+          <h3>Dmitry Vinnik</h3>
           <p>Lead Developer Advocate at Meta</p>
           <div class="person-links">
             <a class="icon icon-x" href="https://twitter.com/DmitryVinnik" title="@DmitryVinnik"></a>
@@ -2137,7 +2344,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/8523418?v=4&amp;s=96" alt="Thomas Vitale" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Thomas Vitale</h4>
+          <h3>Thomas Vitale</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Spring AI Lead Contributor, creator of Arconia, author of <em>Cloud Native Spring in Action</em></p>
           <div class="person-links">
@@ -2153,7 +2360,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/167926?v=4&amp;s=96" alt="Craig Walls" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Craig Walls</h4>
+          <h3>Craig Walls</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Author of <em>Spring AI in Action</em></p>
           <div class="person-links">
@@ -2168,7 +2375,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/65043?v=4&amp;s=96" alt="James Ward" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>James Ward</h4>
+          <h3>James Ward</h3>
           <span class="badge-champion">Java Champion</span>
           <p>Developer Advocate &mdash; Java, Kotlin, Cloud, AI</p>
           <div class="person-links">
@@ -2184,7 +2391,7 @@
       <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/5970214?v=4&amp;s=96" alt="Pascal Wilbrink" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
-          <h4>Pascal Wilbrink</h4>
+          <h3>Pascal Wilbrink</h3>
           <p>Senior Software Developer at OpenValue; creator of the Spring AI AG-UI Java SDK, bringing the AG-UI protocol to Java/Spring AI</p>
           <div class="person-links">
             <a class="icon icon-github" href="https://github.com/pascalwilbrink" title="GitHub"></a>
@@ -2349,6 +2556,17 @@
         <div class="card-links">
           <a class="icon icon-github" href="https://github.com/scarfbench/benchmark" title="GitHub"></a>
           <a class="icon icon-web" href="https://www.ibm.com/new/announcements/scarfbench-a-public-benchmark-for-java-framework-migration" title="Announcement"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-resource">Resource</span>
+        <h3><a href="https://kotlinlang.org/benchmark/">Kotlin Benchmark for AI Coding Agents</a></h3>
+        <p>JetBrains' open benchmark for evaluating AI coding agents on real-world Kotlin tasks &mdash; 105 issues drawn from active open-source Kotlin repositories including ktlint, detekt, and ort, each requiring the agent to read an issue, navigate the project, and produce a patch that passes the project's tests. Public leaderboard, built on the Multi-SWE-bench methodology.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://kotlinlang.org/benchmark/" title="Leaderboard"></a>
+          <a class="icon icon-github" href="https://github.com/Kotlin/kotlin-swe-bench" title="GitHub"></a>
+          <a class="icon icon-web" href="https://blog.jetbrains.com/kotlin/2026/07/introducing-the-kotlin-benchmark-evaluate-ai-coding-agents-on-real-world-kotlin-tasks/" title="Announcement"></a>
         </div>
       </div>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,168 +1,70 @@
-# AI4JVM Site Specification
+# AI4JVM — the curated guide to AI on the JVM
 
-AI4JVM is a curated guide to the Java AI ecosystem — a single-page website covering agent frameworks, inference engines, code assistants, key people, and learning resources.
+> The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.
 
-## Guidelines
+Complete content of https://ai4jvm.com/ in Markdown. This is the full directory; `/llms.txt` has a short index of the same site. Entries are human-curated: each must be specific to Java/JVM developers and actively maintained. See https://github.com/jamesward/ai4jvm/blob/main/CONTRIBUTING.md for the editorial policy.
 
-- Validate accuracy with recent web information
-- **Project activity:** When researching or reviewing projects, check how active they are (recent commits, releases, maintainer responsiveness). If a project is abandoned but still useful (e.g. stable library with no need for updates), keep it but add a note like `⚠️ No longer actively maintained` in its description. If a project is abandoned and no longer useful (e.g. outdated, superseded, or broken), remove it from the site.
+## Latest Java AI News
 
-## SEO
+Latest news and releases from across the Java AI ecosystem — new framework versions, MCP updates, and inference engines.
 
-### Head & Meta
-- **Title tag:** "AI4JVM — Java AI Frameworks, LLM Inference & Tools for the JVM" — keep under 60 characters so it isn't truncated in search results
-- **Meta description:** "The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources." — keep between 150 and 160 characters
-- **Canonical URL:** `https://ai4jvm.com/`
-- Keep Open Graph and Twitter Card meta tags in sync with the title/description above
-- `<meta charset>` must appear within the first 1024 bytes of the document, so it comes first in `<head>`; the Google Analytics tag goes last, just before `</head>`
-- **Theme color:** `<meta name="theme-color" content="#0f1117">` matching the page background
-
-### Structured Data (JSON-LD)
-- Include `WebSite` schema with `@id`, `inLanguage`, `publisher`, and an `about` list naming the site's core topics (Java, Kotlin, JVM, AI, LLMs, MCP)
-- Include a `CollectionPage` schema referencing the `WebSite` via `isPartOf`, with `dateModified` kept in sync with `sitemap.xml`'s `<lastmod>`
-- Include one `ItemList` schema per catalog section — Agent Frameworks & Libraries, Java with Code Assistants, Inference & Training, and People to Follow — enumerating every card as a `ListItem` with name, url, and position. People entries wrap a nested `Person`. This helps search engines understand the site as a directory and surface it for "Java AI frameworks" queries.
-- Every `ItemList` must stay in sync with the cards actually rendered in its section
-- Add a `FAQPage` schema for the FAQ section (see below)
-
-### Heading Hierarchy
-- `<h1>`: One per page (the hero title) — must contain primary keywords "Java" and "AI"
-- `<h2>`: One per major section (News, Agent Frameworks & Libraries, Java with Code Assistants, Inference & Training, People to Follow, FAQ, Resources)
-- `<h3>`: Individual cards/items within sections, including person names in the People section
-- Never skip a heading level — headings must descend sequentially (an `<h4>` directly under an `<h2>` is an accessibility violation)
-- The News section must use `<h2>` (not `<h3>`) for its heading
-
-### Section Introductions
-Each major content section (`<section>`) should have a 1–2 sentence introduction paragraph below its `<h2>` heading. These intro paragraphs provide keyword-rich body text for search engines and context for users. Examples:
-- **News:** "Latest news and releases from across the Java AI ecosystem — new framework versions, MCP updates, and inference engines."
-- **Agent Frameworks & Libraries:** "Open-source frameworks and SDKs for building AI-powered applications on the JVM — from full agent platforms to Model Context Protocol implementations."
-- **Java with Code Assistants:** "Tools that bridge AI coding assistants and the Java ecosystem — MCP servers, skill registries, and IDE integrations."
-- **Inference & Training:** "Run LLM inference, train ML models, and deploy AI workloads directly on the JVM without Python dependencies."
-- **People to Follow:** "Key voices and project leads shaping the Java AI ecosystem."
-- **Resources:** "Talks, tutorials, books, and communities for learning AI development on the JVM."
-
-### FAQ Section
-Add a FAQ section before the Resources section. This targets long-tail search queries. Use `<h2>FAQ</h2>` heading and render as an accordion or simple Q&A list. Each Q&A pair should also be included in FAQPage structured data.
-
-Questions and answers:
-- **"What is the best Java framework for building AI agents?"** — "The most popular choices are Spring AI and LangChain4j. Spring AI is ideal if you're already in the Spring ecosystem, offering portable abstractions across 20+ model providers. LangChain4j provides a standalone library with three levels of abstraction, from low-level prompts to high-level AI Services. Other options include Google ADK for Java, Embabel, and Akka Agents — each with different strengths for specific use cases."
-- **"Can Java run LLMs locally?"** — "Yes. Projects like Jlama and GPULlama3.java run Llama, Mistral, and other models directly on the JVM. Jlama uses Java's Vector API for SIMD-accelerated inference on CPU, while GPULlama3.java leverages TornadoVM for GPU acceleration. For production deployments, ONNX Runtime Java supports hardware-accelerated inference across CUDA, DirectML, and CoreML."
-- **"What is MCP and how does it work with Java?"** — "The Model Context Protocol (MCP) is an open standard that lets AI assistants interact with external tools and data sources. The official MCP Java SDK, maintained by the Spring AI team, provides both client and server implementations with sync/async support and multiple transports (STDIO, Streamable HTTP; SSE deprecated as of 2.0). Helidon MCP and several frameworks also offer MCP support."
-- **"Is Kotlin supported by Java AI frameworks?"** — "Yes. Most Java AI frameworks run on any JVM language. Embabel is written in Kotlin with full Java interop, Koog from JetBrains is a Kotlin-native agent framework, and Tracy provides AI observability for Kotlin. LangChain4j and Spring AI work seamlessly from Kotlin code."
-
-### Sitemap
-- `sitemap.xml` must have `<lastmod>` updated whenever `index.html` content changes
-- Keep `<changefreq>weekly</changefreq>` and `<priority>1.0</priority>`
-
-### Robots.txt
-- Keep `Allow: /` and `Sitemap:` directive for the default `User-agent: *` group
-- Keep the `Content-Signal: search=yes, ai-input=yes, ai-train=yes` directive on the default group — AI4JVM is a public directory meant to be read, indexed, and cited by AI agents
-- Keep explicit `Allow: /` groups for named AI crawlers/assistants (GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, Claude-User, Claude-SearchBot, anthropic-ai, PerplexityBot, Perplexity-User, Google-Extended, Applebot-Extended, CCBot, Amazonbot, Bytespider, meta-externalagent)
-
-### Agent Friendliness
-- Maintain `/llms.txt` (per the [llms.txt spec](https://llmstxt.org)) as a plain-Markdown summary of the site: H1 title, one-line blockquote summary matching the meta description, a short description paragraph, and an H2 "Sections" list linking each `<section id>` anchor with a one-sentence summary matching its section intro paragraph
-- Maintain `/llms-full.txt` as the complete site content in plain Markdown — every section, every card with its description and links, and the full FAQ. Agents that need the whole directory fetch this instead of parsing `index.html`. Regenerate it whenever site content changes.
-- Keep `llms.txt`'s section list in sync with `index.html`'s `<h2>` sections (see Heading Hierarchy above)
-- `index.html`'s `<head>` links to both via `<link rel="alternate" type="text/markdown">`
-
-### Performance
-- No web fonts — use the system font stack only (avoids render-blocking font requests)
-- All images (GitHub avatars) must have explicit `width`/`height`, `loading="lazy"`, and `decoding="async"`, and request a small size via GitHub's avatar sizing parameter (e.g. `?v=4&s=96`) rather than the full-resolution image
-- `<link rel="preconnect">` for third-party origins the page actually loads from (GitHub avatars, Google Tag Manager), with a `dns-prefetch` fallback for the avatar origin
-- The Google Analytics tag is the last thing in `<head>` so it never delays parsing of the title, meta, and inline CSS
-- CSS stays inline in a single `<style>` block (no build step, no extra request); no unused CSS
-
-## Site Structure
-
-- Single `index.html` file (HTML + inline CSS, no build step)
-- Dark theme with card-based layout
-- Sticky nav, hero section, then content sections separated by dividers
-- Responsive: cards collapse to single column on mobile
-- Preserve the ordering in this spec
-
-## Visual Design
-
-- Dark background (`#0f1117`), card surfaces (`#1e2230`), accent purple (`#6c63ff`), accent blue (`#38bdf8`), accent pink (`#f472b6`)
-- Cards have hover effects (border highlight, slight lift)
-- Badge types: `badge-framework` (purple), `badge-inference` (blue), `badge-assistant` (pink), `badge-resource` (green)
-- Where possible use icons for links - for blog or other use a world / www icon. don't use text labels.
-- In a given section, use different colors for different badge types.
-
-### Link Affordance
-- **Clickable cards:** If a card has a single primary destination (e.g. resource cards with one link), make the entire card an `<a>` tag so clicking anywhere on the card navigates. Keep secondary icon links overlaid on top.
-- **Card titles as links:** For cards with multiple links (frameworks, tools), make the card `h3` title a clickable link to the primary resource (docs or website). Style title links with an underline on hover.
-- **News links:** Underline news item links so they're visually distinct from surrounding text.
-- **Inline text links:** Any link within body text or descriptions should be underlined.
-- **Don't mislead:** Only apply hover lift/border effects to cards that are actually clickable. Non-clickable cards should still have a subtle hover border but no translateY lift.
-
-## Hero
-
-- Title: "Java meets **Artificial Intelligence**" (gradient text on "Artificial Intelligence")
-- Subtitle: "The curated guide to AI on the JVM — compare agent frameworks, inference engines, code assistants, and find the people and resources shaping the Java AI ecosystem."
-
----
-
-## News
-
-Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
-Note: Order by date, newest first. Don't show news older than 3 months
-
-- https://github.com/modelcontextprotocol/java-sdk/releases/tag/v2.0.1
-- https://quarkus.io/blog/a2a-java-sdk-1-2-0-final-released/
-- https://github.com/quarkiverse/quarkus-langchain4j/releases/tag/1.13.0
-- https://javapro.io/2026/08/18/devops-patterns-and-java-26-for-on-premises-llm-platforms-in-safety-critical-environments/
-- https://micronaut.io/2026/08/17/micronaut-framework-5-1-1-released/
-- https://javapro.io/2026/08/13/building-ai-driven-java-systems-with-spring-ai-and-java-26/
-- https://github.com/langchain4j/langchain4j/releases/tag/1.19.0
-- https://thetalkingapp.medium.com/spring-ai-recipe-building-a-graph-based-agentic-workflow-with-langgraph4j-0fbfcce25a57
-- https://inside.java/2026/08/12/java-mcp-migration/
-- https://github.com/embabel/embabel-agent/releases/tag/v1.5.0
-- https://thetalkingapp.medium.com/spring-ai-recipe-filtering-rag-results-with-metadata-bef2f8a7cb72
-- https://foojay.io/today/introduction-to-retrieval-augmented-generation-with-java-and-mongodb/
-- https://github.com/a2aproject/a2a-java/releases/tag/v1.2.0.Final
-- https://camel.apache.org/blog/2026/08/camel-ai-tools-mcp-422/
-- https://github.com/agentscope-ai/agentscope-java/releases/tag/v2.0.1
-- https://www.infoq.com/news/2026/08/java-news-roundup-jul27-2026/
-- https://github.com/jakartaee/agentic-ai/releases/tag/1.0.0-M1
-- https://foojay.io/today/jakarta-agentic-ai-hits-its-first-milestone/
-- https://foojay.io/today/how-to-create-a-spring-boot-fraud-scoring-service/
-- https://inside.java/2026/07/30/under-the-hat-empowering-gpu-acceleration-for-java/
-- https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/
-- https://github.com/beehive-lab/GPULlama3.java/releases/tag/v1.0.0
-- https://github.com/micronaut-projects/micronaut-langchain4j/releases/tag/v2.2.0
-- https://blog.jetbrains.com/air/2026/07/what-s-new-air-gets-more-agents-local-models-and-java-kotlin-code-intelligence/
-- https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.1.0
-- https://micronaut.io/2026/07/27/micronaut-framework-5-1-0-release/
-- https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54
-- https://inside.java/2026/07/25/design-java-mcp-tool/
-- https://github.com/embabel/embabel-agent/releases/tag/v1.0.0
-- https://github.com/beehive-lab/TornadoVM/releases/tag/v5.2.0-jdk21
-- https://inside.java/2026/07/23/podcast-063/
-- https://foojay.io/today/ai-found-the-bugs-whos-patching-your-eol-java-code/
-- https://github.com/JetBrains/koog/releases/tag/1.1.1
-- https://javapro.io/2026/07/16/solving-spring-ais-ui-challenge-with-ag-uis-java-sdk/
-- https://github.com/langchain4j/langchain4j/releases/tag/1.18.0
-- https://foojay.io/today/i-asked-github-copilot-to-profile-a-java-app-it-found-a-bug-in-my-heap-sizing-and-offered-to-fix-it/
-- https://quarkus.io/blog/quarkus-langchain4j-opa-guardrails/
-- https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.0.0
-- https://github.com/agentscope-ai/agentscope-java/releases/tag/v2.0.0
-- https://javapro.io/2026/07/08/langchain4j-agentic-workflows-from-ai-calls-to-multi-agent-systems-in-java/
-- https://foojay.io/today/building-ai-systems-with-mongodb-implementing-the-planning-pattern/
-- https://a2aproject.github.io/a2a-java/posts/a2a-java-sdk-1-1-0-final-released/
-- https://spring.io/blog/2026/06/23/spring-ai-self-correcting-structured-output
-- https://spring.io/blog/2026/06/15/spring-ai-composable-tool-calling
-- https://quarkus.io/blog/a2a-java-sdk-1-0-0-final-released/
-- https://spring.io/blog/2026/06/12/spring-ai-2-0-0-GA-available-now
-- https://github.com/modelcontextprotocol/java-sdk/releases/tag/v2.0.0
-- https://java.agentscope.io/v2/en/blogs/agentscope-v2-release.html
-- https://javapro.io/2026/06/03/the-gen-ai-iceberg-java-tooling-edition/
-- https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/
-- https://quarkus.io/blog/introducing-voting-pattern/
-- https://micronaut.io/2026/05/20/micronaut-framework-5-0-0-released/
-- https://blog.ovhcloud.com/devoxx-france-2026/
-
----
+- [MCP Java SDK 2.0.1 Released](https://github.com/modelcontextprotocol/java-sdk/releases/tag/v2.0.1) — first patch on the 2.0 line: upgrades the conformance suite to 0.1.16 and Spring AI conformance to 2.0.0 GA, bounds HTTP and STDIO server/client reads, and fixes SSE event classification, pagination, and unregistered-handler behavior in stateless servers
+- [A2A Java SDK 1.2.0.Final Released](https://quarkus.io/blog/a2a-java-sdk-1-2-0-final-released/) — hardens the authorization model with read-authorization enforcement on referenced task lookups, adds a `TaskStreamLifecycleHook` SPI for stream lifecycle management, and ships breaking changes including method renames and a `TaskState` enum change
+- [Quarkus LangChain4j 1.13.0 Released](https://github.com/quarkiverse/quarkus-langchain4j/releases/tag/1.13.0) — upgrades to LangChain4j 1.19.0 and the latest MCP client spec, replaces the Qdrant gRPC client with a REST client, adds GPULlama3 tool-calling support, and expands the Dev UI with a Guardrails page and RAG context visibility
+- [DevOps Patterns and Java 26 for On-Premises LLM Platforms in Safety-Critical Environments](https://javapro.io/2026/08/18/devops-patterns-and-java-26-for-on-premises-llm-platforms-in-safety-critical-environments/) — Cornelius May covers RAG-on-Kubernetes architecture, Java 26's AOT caching, Vector API, and Structured Concurrency, and treating prompts as versioned, governed code
+- [Micronaut Framework 5.1.1 Released](https://micronaut.io/2026/08/17/micronaut-framework-5-1-1-released/) — maintenance release covering Micronaut Core and Micronaut OpenAPI
+- [Building AI-Driven Java Systems with Spring AI and Java 26](https://javapro.io/2026/08/13/building-ai-driven-java-systems-with-spring-ai-and-java-26/) — treats LLMs as first-class components with explicit responsibilities, leveraging Java 26's Virtual Threads and Structured Concurrency for efficient I/O-bound agentic workflows
+- [LangChain4j 1.19.0 Released](https://github.com/langchain4j/langchain4j/releases/tag/1.19.0) — adds MCP client improvements, Anthropic Batch Chat Model support, a Milvus V2 service update with hybrid search, watsonx.ai Model Gateway support, and Google GenAI thinking support
+- [Spring AI Recipe: Building a Graph-Based Agentic Workflow with LangGraph4j](https://thetalkingapp.medium.com/spring-ai-recipe-building-a-graph-based-agentic-workflow-with-langgraph4j-0fbfcce25a57) — Craig Walls builds a customer-support workflow with LangGraph4j nodes for classification, billing, and technical support integrated with Spring AI, contrasting LangGraph4j's framework-neutral graphs with Spring AI Alibaba Graph
+- [Evolving a Java MCP Server During MCP Specification Upgrades](https://inside.java/2026/08/12/java-mcp-migration/) — Ana-Maria Mihalceanu shows how to adopt the MCP 2026-07-28 spec while staying compatible with older clients, routing new stateless requests through an adapter layer alongside the legacy initialized workflow
+- [Embabel Agent 1.5.0 Released](https://github.com/embabel/embabel-agent/releases/tag/v1.5.0) — migrates to Spring AI 2.0 GA (Spring Boot 4, Jackson 3), adds Alibaba Cloud DashScope model support, RAG chunk-metadata and full-text scoring improvements, and a vendor-neutral streaming tool loop
+- [Spring AI Recipe: Filtering RAG Results with Metadata](https://thetalkingapp.medium.com/spring-ai-recipe-filtering-rag-results-with-metadata-bef2f8a7cb72) — Craig Walls shows how attaching metadata to document chunks and filtering vector-store queries with Spring AI's `VectorStore` and `QuestionAnswerAdvisor` narrows RAG retrieval before the LLM sees it
+- [Introduction to Retrieval-Augmented Generation with Java and MongoDB](https://foojay.io/today/introduction-to-retrieval-augmented-generation-with-java-and-mongodb/) — tutorial building a JAX-RS/Helidon RAG service with LangChain4j and MongoDB Atlas as a combined vector store and operational database, retrieving context to answer HR policy questions before calling the LLM
+- [A2A Java SDK 1.2.0.Final Released](https://github.com/a2aproject/a2a-java/releases/tag/v1.2.0.Final) — adds programmatic auth wiring and a TaskStreamLifecycleHook, upgrades to Quarkus 3.37.3, and ships breaking changes: cross-module split-package resolution, `TaskState.UNRECOGNIZED` renamed to `TASK_STATE_UNSPECIFIED` per spec, and corrected authorization enforcement on referenced task lookups
+- [Camel Routes as AI Tools: Unified Tooling and MCP Server in Camel 4.22](https://camel.apache.org/blog/2026/08/camel-ai-tools-mcp-422/) — introduces `camel-ai-tool`, a unified tool abstraction so a route defined once works with LangChain4j, Spring AI, or OpenAI, and `camel-mcp-server`, which exposes tagged routes directly as MCP tools
+- [AgentScope Java 2.0.1 Released](https://github.com/agentscope-ai/agentscope-java/releases/tag/v2.0.1) — maintenance release expanding model-provider support (DeepSeek, GLM, Kimi, MiniMax) and hardening Harness subagent/permission handling, plus fixes for memory leaks and streaming tool-arg repair
+- [InfoQ Java News Roundup](https://www.infoq.com/news/2026/08/java-news-roundup-jul27-2026/) — weekly Java ecosystem roundup covering two new JDK 28 JEPs, Jakarta Agentic AI's first milestone release, GPULlama3.java 1.0.0 GA, GraalVM 25.2's new Graal Script Agent, and point releases across Micronaut, Quarkus, and JobRunr
+- [Jakarta Agentic AI 1.0.0-M1](https://github.com/jakartaee/agentic-ai/releases/tag/1.0.0-M1) — first milestone release of the new Jakarta EE agentic AI specification, adding TCK behavioral-test infrastructure and module/javadoc improvements ahead of 1.0
+- [Jakarta Agentic AI Hits Its First Milestone](https://foojay.io/today/jakarta-agentic-ai-hits-its-first-milestone/) — Dominika Tasarz walks through the 1.0.0-M1 release now on Maven Central: the draft spec's annotation model (`@Agent`, `@Trigger`, `@Decision`, `@Action`, `@Outcome`, `@HandleException`), a new CDI `@WorkflowScoped` context, and a vendor-neutral `LargeLanguageModel` facade
+- [How to Create a Spring Boot Fraud Scoring Service](https://foojay.io/today/how-to-create-a-spring-boot-fraud-scoring-service/) — builds a production credit-card fraud detection REST API with Spring Boot and the pure-Java Deep Netts deep-learning library, embedding the model directly in the app instead of a separate Python inference server
+- [Under the HAT: Empowering GPU Acceleration for Java](https://inside.java/2026/07/30/under-the-hat-empowering-gpu-acceleration-for-java/) — Juan Fumero introduces the Heterogeneous Accelerator Toolkit, which uses OpenJDK Project Babylon's code-reflection APIs to translate sections of Java programs into CUDA and OpenCL at runtime, managing generated code and data migration automatically
+- [Connecting Java Reinforcement Learning to Python Gymnasium](https://javapro.io/2026/07/29/connecting-java-reinforcement-learning-to-python-gymnasium/) — bridges Java RL code to Python's Gymnasium library via JavaCPP, covering Python lifecycle management and NumPy data transfer, starting with CartPole before scaling up to CARLA
+- [GPULlama3.java 1.0.0 Released](https://github.com/beehive-lab/GPULlama3.java/releases/tag/v1.0.0) — first major release of the GPU-accelerated Java LLM inference engine, now on Maven Central as `io.github.beehive-lab:gpu-llama3` with auto-activating `1.0.0-jdk21` and `1.0.0-jdk25` builds, making TornadoVM-backed GPU inference a plain Maven or Gradle dependency
+- [Micronaut LangChain4j 2.2.0 Released](https://github.com/micronaut-projects/micronaut-langchain4j/releases/tag/v2.2.0) — adds LangChain4j agentic support, Chroma embedding-store support, guardrails resolved from Micronaut beans, and evaluation testing to the official Micronaut integration
+- [JetBrains Air Adds Java and Kotlin Code Intelligence](https://blog.jetbrains.com/air/2026/07/what-s-new-air-gets-more-agents-local-models-and-java-kotlin-code-intelligence/) — the agent-first tool gains language intelligence powered by the IntelliJ IDEA code engine (Beta) for mixed Java/Kotlin projects — jump-to-definition, find usages, symbol search, and error highlighting on agent-modified code — plus local models via Ollama and LM Studio through ACP-compatible agents
+- [Spring AI AgentCore 2.1.0 Released](https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.1.0) — latest release of the Spring Boot integrations for Amazon Bedrock AgentCore, following the 2.0.0 GA
+- [Micronaut Framework 5.1.0 Released](https://micronaut.io/2026/07/27/micronaut-framework-5-1-0-release/) — Micronaut LangChain4j upgraded to 2.2.0 with Oracle chat-memory auto-configuration, Chroma embedding-store support, bean-resolved AI-service guardrails, and agentic support, alongside a Micronaut MCP update to track the latest MCP Java SDK
+- [When Prompts Become Plugins: Generating User Extensions with Graal Script Agent](https://medium.com/graalvm/when-prompts-become-plugins-34a737d30f54) — introduces a library for turning end-user prompts into sandboxed, reusable JavaScript or Python extensions that run locally within application-defined boundaries
+- [Pairing In-Process and Hosted Embeddings for Java MCP Tool Development](https://inside.java/2026/07/25/design-java-mcp-tool/) — designing an MCP server on Helidon that supports both local (DJL/MiniLM) and hosted (OpenAI) embedding models behind a stable tool interface
+- [Embabel 1.0.0 Reaches GA](https://github.com/embabel/embabel-agent/releases/tag/v1.0.0) — the JVM agent framework's first stable release promotes experimental RAG APIs to production status, adds generic media/document support, exposes MCP server health via Spring Boot Actuator, and now resolves entirely from Maven Central
+- [TornadoVM 5.2.0 Adds Native FP8 Tensor-Core Support](https://github.com/beehive-lab/TornadoVM/releases/tag/v5.2.0-jdk21) — packed half2 support and native FP8 conversion with FP8/BF16 tensor-core MMA for the CUDA backend, plus expanded BFloat16 array support and new activation-function epilogues (SiLU, Sigmoid, Tanh, HardSwish)
+- [Inside Java Podcast: AI Solutions with Spring AI 2.0](https://inside.java/2026/07/23/podcast-063/) — Dan Vega and Lize Raes discuss Spring AI 2.0, deterministic agents, and MCP servers/skills, recorded at JavaOne 2026
+- [AI Found the Bugs. Who's Patching Your EOL Java Code?](https://foojay.io/today/ai-found-the-bugs-whos-patching-your-eol-java-code/) — argues AI-assisted vulnerability discovery is now outpacing human-speed patching for unsupported Java dependencies, raising security-economics questions for the ecosystem
+- [Koog 1.1.1 Released](https://github.com/JetBrains/koog/releases/tag/1.1.1) — adds Spring Boot 4 / Spring AI 2.0 starters and a WebClient-based HTTP client, non-text tool results (images/files), Amazon Bedrock memory auto-discovery, and a fix for a Spring AI 2.0 ClassCastException on generic ChatOptions
+- [Solving Spring AI's UI Challenge with AG-UI's Java SDK](https://javapro.io/2026/07/16/solving-spring-ais-ui-challenge-with-ag-uis-java-sdk/) — walks through bridging Spring AI agent backends with frontend UIs like CopilotKit via a standardized streaming protocol
+- [LangChain4j 1.18.0 Released](https://github.com/langchain4j/langchain4j/releases/tag/1.18.0) — introduces a Belief-Desire-Intention (BDI) agentic pattern, crash-resilient Human-in-the-Loop suspend/resume for agentic systems, OpenAI TTS support, and a revamped embedding-model API with per-call parameters and multimodal input
+- [JVM Pulse: Profiling Java with GitHub Copilot](https://foojay.io/today/i-asked-github-copilot-to-profile-a-java-app-it-found-a-bug-in-my-heap-sizing-and-offered-to-fix-it/) — new open-source Copilot canvas extension from Bruno Borges automates GC/JFR profiling and hands off findings to Copilot for AI-driven tuning recommendations
+- [Compiling OPA Policies to WebAssembly for Quarkus LangChain4j Guardrails](https://quarkus.io/blog/quarkus-langchain4j-opa-guardrails/) — sub-millisecond prompt-injection pattern matching via Open Policy Agent rules compiled to Wasm, falling back to an LLM only for inconclusive cases
+- [Spring AI AgentCore SDK v2.0.0 Released](https://github.com/spring-ai-community/spring-ai-agentcore/releases/tag/v2.0.0) — major version release of the open-source Spring Boot integration for Amazon Bedrock AgentCore, with auto-configured invocation endpoints, SSE streaming, and short/long-term memory support
+- [AgentScope Java v2.0.0 Tagged on GitHub](https://github.com/agentscope-ai/agentscope-java/releases/tag/v2.0.0) — formal GA release tag for the dual-layer ReActAgent/HarnessAgent architecture, a unified 28-event observability model, and a new permission engine
+- [LangChain4j Agentic Workflows: From AI Calls to Multi-Agent Systems](https://javapro.io/2026/07/08/langchain4j-agentic-workflows-from-ai-calls-to-multi-agent-systems-in-java/) — tutorial covering sequential, loop, parallel, and conditional workflow patterns, goal-oriented planning, and supervisor-based multi-agent systems in Java
+- [Building AI Systems with MongoDB: Implementing the Planning Pattern](https://foojay.io/today/building-ai-systems-with-mongodb-implementing-the-planning-pattern/) — tutorial building a travel-itinerary AI agent with Jakarta EE, Jakarta Data, LangChain4j, and MongoDB using a Reason-Act-Observe planning loop
+- [A2A Java SDK 1.1.0.Final Released](https://a2aproject.github.io/a2a-java/posts/a2a-java-sdk-1-1-0-final-released/) — first feature release after GA, adding a TaskAuthorizationProvider SPI for per-user task authorization in multi-tenant deployments, plus a new project website
+- [Self-Correcting Structured Output in Spring AI 2.0](https://spring.io/blog/2026/06/23/spring-ai-self-correcting-structured-output) — Christian Tzolov shows how `validateSchema()` detects malformed model output and retries up to three times with the specific validation errors fed back to the model, while `useProviderStructuredOutput()` enforces the schema natively on OpenAI, Anthropic, and Google GenAI
+- [Tool Calling in Spring AI 2.0: A Composable, Agentic Architecture](https://spring.io/blog/2026/06/15/spring-ai-composable-tool-calling) — Christian Tzolov details lifting the tool-execution loop out of each chat model into the advisor chain as a recursive `ToolCallingAdvisor`, with `ToolSearchToolCallingAdvisor` progressive tool disclosure cutting tokens 34–64% across hundreds of tools
+- [A2A Java SDK Reaches 1.0 GA](https://quarkus.io/blog/a2a-java-sdk-1-0-0-final-released/) — the Agent2Agent Java SDK ships 1.0.0.Final with spec classes converted to Java records, full JSON-RPC/gRPC/REST transport support, and a cross-SDK interop test kit, followed by 1.1.0 adding a `TaskAuthorizationProvider` SPI for per-user task authorization
+- [Spring AI 2.0.0 GA Available Now](https://spring.io/blog/2026/06/12/spring-ai-2-0-0-GA-available-now) — built on Spring Boot 4 with Jackson 3 JSON handling and null-safety annotations, tool calling elevated to a composable advisor-chain component for agentic patterns, and Model Context Protocol integration with annotation-driven programming and enterprise security
+- [MCP Java SDK 2.0.0 Reaches GA](https://github.com/modelcontextprotocol/java-sdk/releases/tag/v2.0.0) — first major version since 1.x, tracking the 2025-11-25 MCP spec with spec-accurate JSON Schema 2020-12 validation, enforced required fields, and SSE transport deprecated in favor of Streamable HTTP
+- [AgentScope Java v2.0.0 GA](https://java.agentscope.io/v2/en/blogs/agentscope-v2-release.html) — Alibaba's JVM-native agent framework reaches production-ready GA, with event-streaming, permission-gated tool execution, and a Workspace abstraction for long-running, safely sandboxed agents
+- [The Gen AI Iceberg: Java Tooling Edition](https://javapro.io/2026/06/03/the-gen-ai-iceberg-java-tooling-edition/) — a tiered tour of Java's generative AI tooling, from mainstream frameworks like Spring AI and LangChain4j down to GPU kernel compilation and Project Babylon, arguing the JVM runs AI workloads natively rather than just calling out to them
+- [Koog 1.0 Is Out](https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/) — JetBrains' Kotlin/Java agent framework reaches a stable core with a 1-year API guarantee, a redesigned Java interop layer, decoupled HTTP transport, and OpenTelemetry observability
+- [Parallel Voting and Adaptive Model Selection in Quarkus](https://quarkus.io/blog/introducing-voting-pattern/) — LangChain4j's new voting pattern dispatches tasks to multiple evaluator agents in parallel and aggregates results, paired with dynamic chat model switching to balance cost and quality in agentic workflows
+- [Micronaut Framework 5.0.0 Released](https://micronaut.io/2026/05/20/micronaut-framework-5-0-0-released/) — major platform refresh across 70+ modules adds a new Micronaut MCP module built on the MCP Java SDK, plus updated Micronaut LangChain4j integration, alongside Java 25/Kotlin 2.3 baselines
+- [Devoxx France 2026: OVHcloud Highlights and Key Trends](https://blog.ovhcloud.com/devoxx-france-2026/) — 65 of 259 sessions covered AI and agentic systems, the most-discussed topic, with a shift from experimentation toward production, RAG, observability, and governance
 
 ## Agent Frameworks & Libraries
+
+Open-source frameworks and SDKs for building AI-powered applications on the JVM — from full agent platforms to Model Context Protocol implementations.
 
 ### Spring AI
 - **Badge:** Framework
@@ -376,12 +278,12 @@ Note: Order by date, newest first. Don't show news older than 3 months
 
 ### Google Gen AI Java SDK
 - **Badge:** SDK
-- **Description:** Google's official Java SDK unifying access to the Gemini Developer API and Vertex AI. Supports Gemini text/chat, Imagen image generation, Veo video generation, embeddings, token counting, and automatic function calling, with streaming and async options. Distinct from Google ADK for Java, which is an agent-orchestration framework built on top of it.
+- **Description:** Google's official Java SDK unifying access to the Gemini Developer API and Vertex AI. Supports Gemini text/chat, Imagen image generation, Veo video generation, embeddings, token counting, and automatic function calling. Distinct from Google ADK for Java, which is an agent-orchestration framework built on top of it.
 - **Links:** [GitHub](https://github.com/googleapis/java-genai) · [Docs](https://googleapis.github.io/java-genai/javadoc/)
 
 ### IBM watsonx.ai Java SDK
 - **Badge:** SDK
-- **Description:** IBM's official Java SDK for the watsonx.ai enterprise AI platform. Chat completions, streaming, tool calling, embeddings, text classification/extraction/detection, reranking, and time-series forecasting, for both IBM Cloud and on-premises (CP4D) deployments. Integrates with LangChain4j, Quarkus, and Apache Camel.
+- **Description:** IBM's official Java SDK for the watsonx.ai enterprise AI platform. Chat completions, streaming, tool calling, embeddings, text classification/extraction/detection, reranking, and time-series forecasting, for both IBM Cloud and on-premises deployments. Integrates with LangChain4j, Quarkus, and Apache Camel.
 - **Links:** [GitHub](https://github.com/IBM/watsonx-ai-java-sdk) · [Docs](https://ibm.github.io/watsonx-ai-java-sdk/)
 
 ### SAP AI SDK for Java
@@ -392,7 +294,7 @@ Note: Order by date, newest first. Don't show news older than 3 months
 ### Tiberius
 - **Badge:** Library
 - **Description:** Java security and safety testing framework for Java LLM-enriched applications, integrating with JUnit 5 and Spring Boot so adversarial testing lives in the standard test suite. 200+ attack probes across the OWASP LLM Top 10, probabilistic testing (via PUnit) for non-deterministic LLM outputs, fixture-based regression testing, bias testing, model fingerprinting, and LangChain4j guardrail validation. Apache 2.0.
-- **Links:** [Docs](https://github.com/tiberius-security/tiberius/blob/main/docs/langchain4j-guardrail-testing.md) · [GitHub](https://github.com/tiberius-security/tiberius) · [Blog](https://foojay.io/today/tiberius-a-security-testing-framework-for-llm-applications-in-java/) · [Article](https://dev.karakun.com/2026/07/20/llm-security-testing-java-tiberius.html) · [Podcast](https://foojay.io/today/foojay-podcast-99/)
+- **Links:** [Docs](https://github.com/tiberius-security/tiberius/tree/main/docs) · [GitHub](https://github.com/tiberius-security/tiberius) · [Blog](https://foojay.io/today/tiberius-a-security-testing-framework-for-llm-applications-in-java/) · [Article](https://dev.karakun.com/2026/07/20/llm-security-testing-java-tiberius.html) · [Podcast](https://foojay.io/today/foojay-podcast-99/)
 
 ### Ollama4j
 - **Badge:** SDK
@@ -466,7 +368,7 @@ Note: Order by date, newest first. Don't show news older than 3 months
 
 ### LLM4S
 - **Badge:** Framework
-- **Description:** Scala 3 framework for building LLM applications — multi-provider support (OpenAI, Anthropic, Azure OpenAI, Gemini, DeepSeek, Cohere, Mistral, OpenRouter, Ollama), an agent framework with tool calling via ScalaMeta, RAG/vector stores, multimodal input, and OpenTelemetry/Langfuse tracing. Broader in scope than the site's other Scala entries (kyo-ai, zio-bedrock-converse) — closer to a "LangChain4j for Scala." Pre-1.0, MIT licensed, active development with weekly community dev-hours.
+- **Description:** Scala 3 framework for building LLM applications — multi-provider support (OpenAI, Anthropic, Azure OpenAI, Gemini, DeepSeek, Cohere, Mistral, OpenRouter, Ollama), an agent framework with tool calling via ScalaMeta, RAG/vector stores, multimodal input, and OpenTelemetry/Langfuse tracing. Broader in scope than the site's other Scala entries — closer to a "LangChain4j for Scala." Pre-1.0, MIT licensed, active development with weekly community dev-hours.
 - **Links:** [Website](https://llm4s.org/) · [GitHub](https://github.com/llm4s/llm4s)
 
 ### Agents-Flex
@@ -479,13 +381,9 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** Alibaba Cloud's production-ready framework for agentic, workflow, and multi-agent Java applications, built on top of Spring AI. Graph-based orchestration (`SequentialAgent`, `ParallelAgent`, `RoutingAgent`, `LoopAgent`), multimodal ReactAgent support, MCP integration, and a built-in Admin observability/eval console. JDK 17+, Apache 2.0.
 - **Links:** [GitHub](https://github.com/alibaba/spring-ai-alibaba)
 
----
-
 ## Java with Code Assistants
 
 Technologies that supercharge Java development when paired with AI code assistants — from MCP servers that give agents live Javadoc access, to reusable skill packages and IDE integrations.
-
-**Section focus:** Prioritize tools that bridge the gap between AI assistants and the Java ecosystem — MCP servers, skill registries, IDE plugins, and context providers — over general-purpose AI tools.
 
 ### AI-Git-Bot
 - **Badge:** Assistant
@@ -495,7 +393,7 @@ Technologies that supercharge Java development when paired with AI code assistan
 ### Javadocs.dev MCP Server
 - **Badge:** MCP Server
 - **Description:** Gives AI assistants live access to Java, Kotlin, and Scala library documentation from Maven Central. Six tools including latest-version lookup, Javadoc symbol browsing, and source file retrieval. Connect any MCP client via Streamable HTTP.
-- **Links:** website: https://www.javadocs.dev/
+- **Links:** [Javadocs.dev MCP Server](https://www.javadocs.dev/)
 
 ### JetBrains AI
 - **Badge:** Assistant
@@ -505,7 +403,7 @@ Technologies that supercharge Java development when paired with AI code assistan
 ### SkillsJars
 - **Badge:** Skills
 - **Description:** A packaging format and registry for distributing reusable AI agent skills as Maven/Gradle JARs. Skills are Markdown files (`SKILL.md`) under `META-INF/skills/` that teach AI agents domain-specific patterns. Discover and load skills on demand in Claude Code, Kiro, and Spring AI apps.
-- **Links:** website: https://www.skillsjars.com/
+- **Links:** [SkillsJars](https://www.skillsjars.com/)
 
 ### jvm-skills
 - **Badge:** Skills
@@ -515,17 +413,17 @@ Technologies that supercharge Java development when paired with AI code assistan
 ### Awesome GitHub Copilot
 - **Badge:** Skills
 - **Description:** Awesome Copilot Skills is a curated registry of reusable AI agent skills that developers can plug into agents, providing ready-made capabilities, prompts, and workflows. It helps Java AI developers quickly extend agent functionality without building everything from scratch.
-- **Links:** website: https://awesome-copilot.github.com/skills/?q=java
+- **Links:** [Website](https://awesome-copilot.github.com/skills/?q=java)
 
 ### jOOQ MCP Server
 - **Badge:** MCP Server
 - **Description:** Gives AI assistants live access to jOOQ documentation and examples. Connect any MCP client via Streamable HTTP.
-- **Links:** website: https://jooq-mcp.martinelli.ch/
+- **Links:** [jOOQ MCP Server](https://jooq-mcp.martinelli.ch/)
 
 ### Vaadin MCP Server
 - **Badge:** MCP Server
 - **Description:** Gives AI assistants live access to Vaadin documentation and examples. Connect any MCP client via Streamable HTTP.
-- **Links:** website: https://mcp.vaadin.com/docs/
+- **Links:** [Vaadin MCP Server](https://mcp.vaadin.com/docs/)
 
 ### Quarkus Agent MCP
 - **Badge:** MCP Server
@@ -539,8 +437,8 @@ Technologies that supercharge Java development when paired with AI code assistan
 
 ### Maven Tools MCP
 - **Badge:** MCP Server
-- **Description:** Gives AI agents dependency intelligence from Maven Central — version lookup, upgrade comparisons, CVE and license health signals, and POM-aware resolution across Maven, Gradle, SBT, and Mill projects. Helps agents make safer automated dependency-upgrade decisions.
-- **Links:** [GitHub](https://github.com/arvindand/maven-tools-mcp)
+- **Description:** Gives AI agents dependency intelligence from Maven Central — version lookup, upgrade comparisons, CVE and license health signals, and POM-aware resolution across Maven, Gradle, SBT, and Mill projects.
+- **Links:** [Maven Tools MCP](https://github.com/arvindand/maven-tools-mcp)
 
 ### JVM Pulse
 - **Badge:** Extension
@@ -550,7 +448,7 @@ Technologies that supercharge Java development when paired with AI code assistan
 ### IntelliJ IDEA MCP Server
 - **Badge:** MCP Server
 - **Description:** IntelliJ IDEA's built-in Model Context Protocol server, bundled and enabled by default since version 2025.2. Exposes over 100 IDE tools — code analysis, refactoring, debugging, run configurations, database operations — to external MCP clients like Claude Code, Claude Desktop, Cursor, and VS Code. Distinct from the JetBrains AI Assistant plugin above.
-- **Links:** [Docs](https://www.jetbrains.com/help/idea/mcp-server.html)
+- **Links:** [IntelliJ IDEA MCP Server](https://www.jetbrains.com/help/idea/mcp-server.html)
 
 ### Apache Camel MCP Server
 - **Badge:** MCP Server
@@ -565,17 +463,17 @@ Technologies that supercharge Java development when paired with AI code assistan
 ### Develocity MCP Servers
 - **Badge:** MCP Server
 - **Description:** Two official MCP servers from Gradle Inc.'s Develocity platform — one for per-build data (exceptions, stack traces, test outcomes, cache performance) to investigate failures, and an Analytics server for org-wide queries like flaky-test trends and cache effectiveness. Covers Gradle, Maven, sbt, and Bazel builds.
-- **Links:** [Docs](https://docs.develocity.ai/2026.1/integrations/mcp-servers/)
+- **Links:** [Develocity MCP Servers](https://docs.develocity.ai/2026.1/integrations/mcp-servers/)
 
 ### AssistAI (Eclipse IDE MCP Server)
 - **Badge:** Extension
-- **Description:** Community Eclipse IDE plugin (formerly "eclipse-chatgpt-plugin") that exposes the Eclipse workspace as an MCP server — code analysis, refactoring, build/debug control, and Git operations via EGit — so external AI agents like Claude Code edit through Eclipse's JDT APIs instead of the raw filesystem, keeping incremental compilation and error highlighting in sync. Also bundles an inline AI chat view. MIT licensed.
+- **Description:** Community Eclipse IDE plugin that exposes the Eclipse workspace as an MCP server — code analysis, refactoring, build/debug control, and Git operations via EGit — so external AI agents edit through Eclipse's JDT APIs instead of the raw filesystem, keeping incremental compilation and error highlighting in sync. Also bundles an inline AI chat view. MIT licensed.
 - **Links:** [Eclipse Marketplace](https://marketplace.eclipse.org/content/assistai-eclipse-ide-mcp-server-ai-agents) · [GitHub](https://github.com/gradusnikov/eclipse-chatgpt-plugin)
 
 ### SonarQube MCP Server
 - **Badge:** MCP Server
 - **Description:** Official MCP server from SonarSource exposing SonarQube Cloud/Server code-quality and security analysis to AI coding agents — issue management, security hotspots, quality gates, coverage, and dependency risk across 50+ tools. Distributed as a Docker image.
-- **Links:** [GitHub](https://github.com/SonarSource/sonarqube-mcp-server)
+- **Links:** [SonarQube MCP Server](https://github.com/SonarSource/sonarqube-mcp-server)
 
 ### TDA (Thread Dump Analyzer)
 - **Badge:** MCP Server
@@ -595,22 +493,21 @@ Technologies that supercharge Java development when paired with AI code assistan
 ### SolonCode
 - **Badge:** Assistant
 - **Description:** Open-source, provider-agnostic AI coding agent built on the Solon-AI framework, targeting Java 8–26 runtimes. CLI, web, and desktop-IDE interfaces with auto-edit, approval-based execution, and planning agent modes — an open alternative to Claude Code.
-- **Links:** [GitHub](https://github.com/opensolon/soloncode)
+- **Links:** [SolonCode](https://github.com/opensolon/soloncode)
 
 ### Junie
 - **Badge:** Assistant
 - **Description:** JetBrains' autonomous coding agent — plans and executes multi-step edits, runs tests and the debugger, and opens PRs. Reached GA in June 2026 with a standalone bring-your-own-key CLI (Anthropic, OpenAI, Google, xAI, OpenRouter, Copilot) alongside its JetBrains IDE integration. Distinct from the general-purpose JetBrains AI Assistant above.
 - **Links:** [Docs](https://www.jetbrains.com/help/ai-assistant/junie-agent.html) · [Marketplace](https://plugins.jetbrains.com/plugin/26104-junie-the-ai-coding-agent-by-jetbrains)
 
----
-
 ## Inference & Training
 
 Run models, train classifiers, and do ML inference directly on the JVM — no Python required.
+
 ### Deliverance
 - **Badge:** Inference
 - **Description:** Deliverance is a Java inference engine capable of generating text, tokenizing input, computing embeddings, and more. Can be used as embedded library inside your Java application or as an HTTP server /chat/completion). Deliverance also provides chat and Rag Chat through vibrant-maven-plugin allowing you to chat with your code!
-- **Links:** [GitHub](https://github.com/edwardcapriolo/deliverance) [Dockerhub](https://hub.docker.com/repository/docker/ecapriolo/deliverance/general)
+- **Links:** [GitHub](https://github.com/edwardcapriolo/deliverance) · [Dockerhub](https://hub.docker.com/repository/docker/ecapriolo/deliverance/general)
 
 ### Jlama
 - **Badge:** Inference
@@ -657,515 +554,247 @@ Run models, train classifiers, and do ML inference directly on the JVM — no Py
 - **Description:** Apache's Java-native NLP toolkit — tokenization, part-of-speech tagging, named entity recognition, chunking, parsing, and language detection, with pluggable MaxEnt, Perceptron, Naive Bayes, and SVM classifiers. Actively maintained, with a Java 21-targeted 3.0 branch in progress.
 - **Links:** [Website](https://opennlp.apache.org) · [GitHub](https://github.com/apache/opennlp)
 
----
-
 ## People to Follow
 
 Key voices at the intersection of Java and AI.
-Notes:
-- Alphabetical by last name
-- Indicate if someone is a Java Champion using a badge on its own line (below the name, above the role). Don't repeat "Java Champion" in the role text. Lookup: https://github.com/aalmiray/java-champions/blob/main/java-champions.yml
-- Add profile photos if found.
-- Add Twitter, GitHub, LinkedIn, Bluesky, YouTube, if available.
 
 ### Sandra Ahlgrimm
-
-- **Badge:** Person
-- **Initials:** SA
-- **Photo:** https://avatars.githubusercontent.com/u/5214683?v=4
-- **Role:** Senior Cloud Advocate for Java — Microsoft/GitHub; focused on GitHub Copilot for Java developers and LangChain4j integrations, co-leads a local JUG, and represents Microsoft on the GraalVM Program Advisory Board
+- **Bio:** Senior Cloud Advocate for Java — Microsoft/GitHub; focused on GitHub Copilot for Java developers and LangChain4j integrations, co-leads a local JUG, and represents Microsoft on the GraalVM Program Advisory Board
 - **Links:** [GitHub](https://github.com/sandraahlgrimm) · [LinkedIn](https://www.linkedin.com/in/sandraahlgrimm/)
 
-### Jean-François Arcand
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** JA
-- **Photo:** https://avatars.githubusercontent.com/u/51285?v=4
-- **Role:** Creator of the original Atmosphere Framework, Grizzly, and AsyncHttpClient; now building the new Atmosphere real-time transport layer for Java AI agents
+### Jean-François Arcand (Java Champion)
+- **Bio:** Creator of the original Atmosphere Framework, Grizzly, and AsyncHttpClient; now building the new Atmosphere real-time transport layer for Java AI agents
 - **Links:** [@jfarcand](https://twitter.com/jfarcand) · [GitHub](https://github.com/jfarcand) · [LinkedIn](https://www.linkedin.com/in/jfarcand/)
 
 ### Jaroslav Bachorik
-
-- **Badge:** Person
-- **Initials:** JB
-- **Photo:** https://avatars.githubusercontent.com/u/738413?v=4
-- **Role:** JVM serviceability engineer — Datadog; creator of BTrace and JAFAR, a modern JFR parser whose `jfr-mcp` module lets AI agents analyze JVM Flight Recorder data directly
+- **Bio:** JVM serviceability engineer — Datadog; creator of BTrace and JAFAR, a modern JFR parser whose `jfr-mcp` module lets AI agents analyze JVM Flight Recorder data directly
 - **Links:** [@BachorikJ](https://twitter.com/BachorikJ) · [GitHub](https://github.com/jbachorik) · [Blog](https://jbachorik.github.io)
 
 ### Zineb Bendhiba
-
-- **Badge:** Person
-- **Initials:** ZB
-- **Photo:** https://avatars.githubusercontent.com/u/12056979?v=4
-- **Role:** Principal Software Engineer — IBM; Apache Camel PMC member, maintains Camel Quarkus and Quarkus Qdrant, lead author of Camel 4.22's `camel-ai-tool` and `camel-mcp-server`
+- **Bio:** Principal Software Engineer — IBM; Apache Camel PMC member, maintains Camel Quarkus and Quarkus Qdrant, lead author of Camel 4.22's `camel-ai-tool` and `camel-mcp-server`
 - **Links:** [@ZinebBendhiba](https://x.com/ZinebBendhiba) · [Bluesky](https://bsky.app/profile/zinebbendhiba.com) · [GitHub](https://github.com/zbendhiba) · [LinkedIn](https://www.linkedin.com/in/zbendhiba/) · [Website](https://zinebbendhiba.com/)
 
-### Bruno Borges
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** BB
-- **Photo:** https://avatars.githubusercontent.com/u/129743?v=4
-- **Role:** Principal Program Manager — Microsoft Java Engineering Group
+### Bruno Borges (Java Champion)
+- **Bio:** Principal Program Manager — Microsoft Java Engineering Group
 - **Links:** [@brunoborges](https://twitter.com/brunoborges) · [Bluesky](https://bsky.app/profile/brunoborges.bsky.social) · [GitHub](https://github.com/brunoborges) · [LinkedIn](https://ca.linkedin.com/in/brunocborges) · [Blog](https://blog.brunoborges.info/)
 
 ### Vadim Briliantov
-
-- **Badge:** Person
-- **Initials:** VB
-- **Photo:** https://avatars.githubusercontent.com/u/24360128?v=4
-- **Role:** Technical Lead of Koog / AI Agents Platform — JetBrains
+- **Bio:** Technical Lead of Koog / AI Agents Platform — JetBrains
 - **Links:** [GitHub](https://github.com/Ololoshechkin) · [LinkedIn](https://hu.linkedin.com/in/vadim-briliantov) · [Blog](https://medium.com/@vadim.briliantov)
 
-### Holly Cummins
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** HC
-- **Photo:** https://avatars.githubusercontent.com/u/11509290?v=4
-- **Role:** Senior Principal Software Engineer — IBM Quarkus team
+### Holly Cummins (Java Champion)
+- **Bio:** Senior Principal Software Engineer — IBM Quarkus team
 - **Links:** [@holly_cummins](https://twitter.com/holly_cummins) · [Bluesky](https://bsky.app/profile/hollycummins.com) · [GitHub](https://github.com/holly-cummins) · [LinkedIn](https://linkedin.com/in/holly-k-cummins/) · [Website](https://hollycummins.com)
 
-### Eric Deandrea
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** ED
-- **Photo:** https://avatars.githubusercontent.com/u/363447?v=4
-- **Role:** [Docling Java](https://docling-project.github.io/docling-java/current) project lead, contributor to LangChain4j, Sr. Principal Software Engineer at IBM
+### Eric Deandrea (Java Champion)
+- **Bio:** [Docling Java](https://docling-project.github.io/docling-java/current) project lead, contributor to LangChain4j, Sr. Principal Software Engineer at IBM
 - **Links:** [Bluesky](https://bsky.app/profile/ericdeandrea.dev) · [@edeandrea](https://x.com/edeandrea) · [GitHub](https://github.com/edeandrea) · [LinkedIn](https://www.linkedin.com/in/edeandrea/)
 
 ### Ronald Dehuysser
-
-- **Badge:** Person
-- **Initials:** RD
-- **Photo:** https://avatars.githubusercontent.com/u/567842?v=4
-- **Role:** Creator of JobRunr and ClawRunr
+- **Bio:** Creator of JobRunr and ClawRunr
 - **Links:** [@rdehuyss](https://twitter.com/rdehuyss) · [GitHub](https://github.com/rdehuyss) · [LinkedIn](https://www.linkedin.com/in/ronalddehuysser)
 
 ### Sébastien Deleuze
-
-- **Badge:** Person
-- **Initials:** SD
-- **Photo:** https://avatars.githubusercontent.com/u/141109?v=4
-- **Role:** Spring Framework core committer, Spring AI/MCP integration — Broadcom
+- **Bio:** Spring Framework core committer, Spring AI/MCP integration — Broadcom
 - **Links:** [@sdeleuze](https://x.com/sdeleuze) · [Bluesky](https://bsky.app/profile/seb.deleuze.fr) · [GitHub](https://github.com/sdeleuze) · [LinkedIn](https://www.linkedin.com/in/deleuze) · [Blog](https://seb.deleuze.fr)
 
 ### Iryna Dohndorf
-
-- **Badge:** Person
-- **Dr.-Ing.**
-- **Initials:** ID
-- **Photo:** https://avatars.githubusercontent.com/u/79046580?v=4
-- **Role:** Creator of Tiberius - Java security and safety testing framework for LLM applications; software engineer at Karakun; her work sits at the intersection of Java engineering, AI safety, and antifragile system design
+- **Bio:** Creator of Tiberius — Java security testing framework for LLM applications; software engineer at Karakun; her work sits at the intersection of Java engineering, AI safety, and antifragile system design
 - **Links:** [GitHub](https://github.com/IDohndorf) · [LinkedIn](https://www.linkedin.com/in/iryna-dohndorf/) · [Website](https://iryna-dohndorf.netlify.app/)
 
-### Julien Dubois
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** JD
-- **Photo:** https://avatars.githubusercontent.com/u/316835?v=4
-- **Role:** Creator of JHipster; leads a Developer Relations team at Microsoft focused on agentic developer tools for Java/Spring Boot
+### Julien Dubois (Java Champion)
+- **Bio:** Creator of JHipster; leads a Developer Relations team at Microsoft focused on agentic developer tools for Java/Spring Boot
 - **Links:** [@juliendubois](https://twitter.com/juliendubois) · [Bluesky](https://bsky.app/profile/jdubois.bsky.social) · [GitHub](https://github.com/jdubois) · [LinkedIn](https://www.linkedin.com/in/juliendubois/) · [Website](https://www.julien-dubois.com/)
 
-### Markus Eisele
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** ME
-- **Photo:** https://avatars.githubusercontent.com/u/1358554?v=4
-- **Role:** Developer Advocate — IBM Research, JavaLand founder
+### Markus Eisele (Java Champion)
+- **Bio:** Developer Advocate — IBM Research, JavaLand founder
 - **Links:** [@myfear](https://twitter.com/myfear) · [Bluesky](https://bsky.app/profile/myfear.com) · [GitHub](https://github.com/myfear) · [LinkedIn](https://www.linkedin.com/in/markuseisele/) · [Blog](https://blog.eisele.net/)
 
-### Mario Fusco
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** MF
-- **Photo:** https://avatars.githubusercontent.com/u/372781?v=4
-- **Role:** LangChain4j core team, Sr. Principal Software Engineer at IBM
+### Mario Fusco (Java Champion)
+- **Bio:** LangChain4j core team, Sr. Principal Software Engineer at IBM
 - **Links:** [@mariofusco](https://x.com/mariofusco) · [GitHub](https://github.com/mariofusco) · [LinkedIn](https://www.linkedin.com/in/mario-fusco-3467213/)
 
-### Clement Escoffier
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** CE
-- **Photo:** https://avatars.githubusercontent.com/u/402301?v=4
-- **Role:** Red Hat Distinguished Engineer, Quarkus co-creator, works on the Quarkus LangChain4j extension
+### Clement Escoffier (Java Champion)
+- **Bio:** Red Hat Distinguished Engineer, Quarkus co-creator, works on the Quarkus LangChain4j extension
 - **Links:** [GitHub](https://github.com/cescoffier) · [foojay](https://foojay.io/today/author/clement-escoffier/)
 
-### Antonio Goncalves
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** AG
-- **Photo:** https://avatars.githubusercontent.com/u/729277?v=4
-- **Role:** Principal Software Engineer at Microsoft CoreAI, ParisJUG, Devoxx France, Café IA, book author
+### Antonio Goncalves (Java Champion)
+- **Bio:** Principal Software Engineer at Microsoft CoreAI, ParisJUG, Devoxx France, Café IA, book author
 - **Links:** [@agoncal](https://twitter.com/agoncal) · [Bluesky](https://bsky.app/profile/agoncal.bsky.social) · [GitHub](https://github.com/agoncal) · [LinkedIn](https://www.linkedin.com/in/agoncal/) · [Blog](https://antoniogoncalves.org)
 
 ### Ilayaperumal Gopinathan
-
-- **Badge:** Person
-- **Initials:** IG
-- **Photo:** https://avatars.githubusercontent.com/u/151690?v=4
-- **Role:** Spring AI team, Broadcom; regularly drives Spring AI release announcements
+- **Bio:** Spring AI team, Broadcom; regularly drives Spring AI release announcements
 - **Links:** [GitHub](https://github.com/ilayaperumalg) · [Spring.io](https://spring.io/authors/ilayaperumalg/)
 
-### Frank Greco
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** FG
-- **Photo:** https://avatars.githubusercontent.com/u/193434?v=4
-- **Role:** NYJavaSIG founder, AI 4 Java educator, JSR 381 co-author
+### Frank Greco (Java Champion)
+- **Bio:** NYJavaSIG founder, AI 4 Java educator, JSR 381 co-author
 - **Links:** [@frankgreco](https://twitter.com/frankgreco) · [Bluesky](https://bsky.app/profile/frankgreco.bsky.social) · [GitHub](https://github.com/fgreco55) · [LinkedIn](https://www.linkedin.com/in/frankdgreco/) · [Website](https://ai4java.com)
 
-### Ivar Grimstad
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** IG
-- **Photo:** https://avatars.githubusercontent.com/u/149188?v=4
-- **Role:** Jakarta EE Developer Advocate — Eclipse Foundation; speaks on bringing AI to Jakarta EE (Jakarta Agentic AI)
+### Ivar Grimstad (Java Champion)
+- **Bio:** Jakarta EE Developer Advocate — Eclipse Foundation; speaks on bringing AI to Jakarta EE (Jakarta Agentic AI)
 - **Links:** [@ivar_grimstad](https://twitter.com/ivar_grimstad) · [Bluesky](https://bsky.app/profile/theguywiththeduketattoo.com) · [GitHub](https://github.com/ivargrimstad) · [LinkedIn](https://www.linkedin.com/in/ivargrimstad/) · [Website](https://www.agilejava.eu)
 
 ### Emmanuel Hugonnet
-
-- **Badge:** Person
-- **Initials:** EH
-- **Photo:** https://avatars.githubusercontent.com/u/73053?v=4
-- **Role:** Software Engineer — IBM; WildFly core contributor driving most of the recent AI work across WildFly AI Feature Pack and LangChain4j-CDI
+- **Bio:** Software Engineer — IBM; WildFly core contributor driving most of the recent AI work across WildFly AI Feature Pack and LangChain4j-CDI
 - **Links:** [@ehsavoie](https://twitter.com/ehsavoie) · [Bluesky](https://bsky.app/profile/ehsavoie.bsky.social) · [GitHub](https://github.com/ehsavoie) · [LinkedIn](https://www.linkedin.com/in/ehsavoie/) · [Website](https://www.ehsavoie.com)
 
-### Rod Johnson
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** RJ
-- **Photo:** https://avatars.githubusercontent.com/u/1916583?v=4
-- **Role:** Creator of Spring Framework, CEO of Embabel
+### Rod Johnson (Java Champion)
+- **Bio:** Creator of Spring Framework, CEO of Embabel
 - **Links:** [@springrod](https://twitter.com/springrod) · [GitHub](https://github.com/johnsonr) · [LinkedIn](https://www.linkedin.com/in/johnsonroda/) · [Blog](https://medium.com/@springrod)
 
 ### Daniel Kec
-
-- **Badge:** Person
-- **Initials:** DK
-- **Photo:** https://avatars.githubusercontent.com/u/1773630?v=4
-- **Role:** Helidon developer — Oracle
+- **Bio:** Helidon developer — Oracle
 - **Links:** [@danielkec](https://twitter.com/danielkec) · [Bluesky](https://bsky.app/profile/kec.bsky.social) · [GitHub](https://github.com/danielkec) · [LinkedIn](https://www.linkedin.com/in/danielkec/)
 
-### Kenneth Kousen
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** KK
-- **Photo:** https://avatars.githubusercontent.com/u/22784?v=4
-- **Role:** Author of six books including *Kotlin Cookbook* and *Modern Java Recipes*. O'Reilly instructor for AI + Java courses. Professor of Practice in Computer Science at Trinity College. President of Kousen IT, Inc.
+### Kenneth Kousen (Java Champion)
+- **Bio:** Author of six books including Kotlin Cookbook and Modern Java Recipes. O’Reilly instructor for AI + Java courses. Professor of Practice in Computer Science at Trinity College. President of Kousen IT, Inc.
 - **Links:** [@kenkousen](https://twitter.com/kenkousen) · [Bluesky](https://bsky.app/profile/kousenit.com) · [GitHub](https://github.com/kousen) · [LinkedIn](https://www.linkedin.com/in/kenkousen/) · [Website](https://www.kousenit.com/) · [Newsletter](https://kenkousen.substack.com) · [YouTube](https://youtube.com/@talesfromthejarside)
 
-### Guillaume Laforge
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** GL
-- **Photo:** https://avatars.githubusercontent.com/u/47907?v=4
-- **Role:** Google Developer Advocate — Java, Groovy, AI
+### Guillaume Laforge (Java Champion)
+- **Bio:** Google Developer Advocate — Java, Groovy, AI
 - **Links:** [@glaforge](https://twitter.com/glaforge) · [Bluesky](https://bsky.app/profile/glaforge.bsky.social) · [GitHub](https://github.com/glaforge) · [LinkedIn](https://www.linkedin.com/in/glaforge/) · [Blog](https://glaforge.dev/)
 
 ### Dmytro Liubarskyi
-
-- **Badge:** Person
-- **Initials:** DL
-- **Photo:** https://avatars.githubusercontent.com/u/3154404?v=4
-- **Role:** Creator of LangChain4j, Principal Architect — IBM
+- **Bio:** Creator of LangChain4j, Principal Architect — IBM
 - **Links:** [Bluesky](https://bsky.app/profile/dmythro.bsky.social) · [GitHub](https://github.com/dliubarskyi) · [LinkedIn](https://www.linkedin.com/in/dmytro-liubarskyi/)
 
-### Josh Long
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** JL
-- **Photo:** https://avatars.githubusercontent.com/u/54473?v=4
-- **Role:** Spring Developer Advocate at Broadcom
+### Josh Long (Java Champion)
+- **Bio:** Spring Developer Advocate at Broadcom
 - **Links:** [@starbuxman](https://twitter.com/starbuxman) · [Bluesky](https://bsky.app/profile/starbuxman.joshlong.com) · [GitHub](https://github.com/joshlong) · [LinkedIn](https://www.linkedin.com/in/joshlong/) · [Spring Blog](https://spring.io/authors/joshlong/)
 
 ### T. Jake Luciani
-
-- **Badge:** Person
-- **Initials:** TK
-- **Photo:** https://avatars.githubusercontent.com/u/44456?v=4
-- **Role:** Creator of Jlama — Java LLM inference
+- **Bio:** Creator of Jlama — Java LLM inference
 - **Links:** [@tjake](https://twitter.com/tjake) · [GitHub](https://github.com/tjake) · [LinkedIn](https://www.linkedin.com/in/tjake/)
 
 ### Loïc Magnette
-
-- **Badge:** Person
-- **Initials:** LM
-- **Photo:** https://avatars.githubusercontent.com/u/6390187?v=4
-- **Role:** Senior Software Engineer — Oniryx; BeJUG (Belgian Java User Group) co-organizer, writes and speaks on LangChain4j agentic workflows for Quarkus
+- **Bio:** Senior Software Engineer at Oniryx; BeJUG (Belgian Java User Group) co-organizer, writes and speaks on LangChain4j agentic workflows for Quarkus
 - **Links:** [@LoMagnette](https://x.com/LoMagnette) · [Bluesky](https://bsky.app/profile/lomagnette.bsky.social) · [GitHub](https://github.com/lomagnette) · [LinkedIn](https://www.linkedin.com/in/lomagnette/) · [Blog](https://lomagnette.github.io/)
 
 ### François Martin
-
-- **Badge:** Person
-- **Initials:** FM
-- **Photo:** https://avatars.githubusercontent.com/u/14319020?v=4
-- **Role:** International speaker and author, Oracle ACE Associate, senior full-stack software engineer
+- **Bio:** International speaker and author, Oracle ACE Associate, senior full-stack software engineer
 - **Links:** [@fmartin_](https://x.com/fmartin_) · [GitHub](https://github.com/martinfrancois) · [LinkedIn](https://www.linkedin.com/in/fran%c3%a7oismartin/) · [Bluesky](https://bsky.app/profile/fmartin.ch) · [YouTube](https://www.youtube.com/@fmartindev) · [Website](https://fmartin.ch)
 
 ### Simon Martinelli
-
-- **Badge:** Person
-- **Initials:** MP
-- **Photo:** https://avatars.githubusercontent.com/u/593352?v=4
-- **Role:** Creator of AI Unfied Process and jOOQ MCP Server
+- **Bio:** Creator of AI Unfied Process and the jOOQ MCP Server
 - **Links:** [@simas_ch](https://twitter.com/simas_ch) · [GitHub](https://github.com/simach) · [LinkedIn](https://www.linkedin.com/in/simonmartinelli/)
 
-### Ana-Maria Mihalceanu
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** AM
-- **Photo:** https://avatars.githubusercontent.com/u/9703337?v=4
-- **Role:** Senior Developer Advocate, Java Platform Group at Oracle; writes and speaks on Java MCP tooling and AI, co-founder of the Bucharest Software Craftsmanship Community
+### Ana-Maria Mihalceanu (Java Champion)
+- **Bio:** Senior Developer Advocate, Java Platform Group at Oracle; writes and speaks on Java MCP tooling and AI, co-founder of the Bucharest Software Craftsmanship Community
 - **Links:** [@ammbra1508](https://twitter.com/ammbra1508) · [GitHub](https://github.com/ammbra) · [LinkedIn](https://www.linkedin.com/in/ana-maria-mihalceanu-1508/)
 
 ### Vishal Mysore
-
-- **Badge:** Person
-- **Initials:** VM
-- **Photo:** https://avatars.githubusercontent.com/u/25938717?v=4
-- **Role:** Creator of Tools4AI
+- **Bio:** Creator of Tools4AI
 - **Links:** [GitHub](https://github.com/vishalmysore) · [LinkedIn](https://www.linkedin.com/in/vishalrow/) · [Blog](https://medium.com/@visrow)
 
-### Daniel Oh
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** DO
-- **Photo:** https://avatars.githubusercontent.com/u/14066977?v=4
-- **Role:** Senior Principal Developer Advocate — Red Hat; CNCF Ambassador speaking on agentic AI and cloud-native Java
+### Daniel Oh (Java Champion)
+- **Bio:** Senior Principal Developer Advocate — Red Hat; CNCF Ambassador speaking on agentic AI and cloud-native Java
 - **Links:** [@danieloh30](https://twitter.com/danieloh30) · [Bluesky](https://bsky.app/profile/danieloh30.bsky.social) · [LinkedIn](https://www.linkedin.com/in/daniel-oh-083818112/)
 
 ### Michalis Papadimitriou
-
-- **Badge:** Person
-- **Initials:** MP
-- **Photo:** https://avatars.githubusercontent.com/u/8652854?v=4
-- **Role:** Research Fellow, University of Manchester and Senior Software Engineer at Neo4j; TornadoVM core maintainer and lead author of GPULlama3.java, GPU-accelerated LLM inference in pure Java
+- **Bio:** Research Fellow, University of Manchester and Senior Software Engineer at Neo4j; TornadoVM core maintainer and lead author of GPULlama3.java, GPU-accelerated LLM inference in pure Java
 - **Links:** [GitHub](https://github.com/mikepapadim) · [LinkedIn](https://www.linkedin.com/in/michalis-papadimitriou/) · [Website](https://mpapadimitriou.com/)
 
 ### Konstantin Pavlov
-
-- **Badge:** Person
-- **Initials:** KP
-- **Photo:** https://avatars.githubusercontent.com/u/1517853?v=4
-- **Role:** Creator of Tachyon; maintainer of mokksy.dev and LangChain4j Kotlin extensions
+- **Bio:** Creator of Tachyon; maintainer of mokksy.dev and LangChain4j Kotlin extensions
 - **Links:** [Bluesky](https://bsky.app/profile/kpavlov.me) · [GitHub](https://github.com/kpavlov) · [Blog](https://kpavlov.me)
 
 ### Susanne Pieterse
-
-- **Badge:** Person
-- **Initials:** SP
-- **Photo:** https://avatars.githubusercontent.com/u/18641509?v=4
-- **Role:** Senior Software Engineer & iSAQB-certified Software Architect — OPEN.nl; LangChain4j contributor teaching Java teams to build reliable AI agents
+- **Bio:** Senior Software Engineer & iSAQB-certified Software Architect — OPEN.nl; LangChain4j contributor teaching Java teams to build reliable AI agents
 - **Links:** [Bluesky](https://bsky.app/profile/susivic.bsky.social) · [GitHub](https://github.com/Sus4nne)
 
 ### Mark Pollack
-
-- **Badge:** Person
-- **Initials:** MP
-- **Photo:** https://avatars.githubusercontent.com/u/247466?v=4
-- **Role:** Spring AI project lead
+- **Bio:** Spring AI project lead
 - **Links:** [@markpollack](https://twitter.com/markpollack) · [GitHub](https://github.com/markpollack) · [LinkedIn](https://www.linkedin.com/in/marklpollack/)
 
 ### Lize Raes
-
-- **Badge:** Person
-- **Initials:** LR
-- **Photo:** https://avatars.githubusercontent.com/u/49833622?v=4
-- **Role:** LangChain4j core team, Developer Advocate at Oracle
+- **Bio:** LangChain4j core team, Developer Advocate at Oracle
 - **Links:** [@LizeRaes](https://twitter.com/LizeRaes) · [GitHub](https://github.com/LizeRaes) · [LinkedIn](https://www.linkedin.com/in/lize-raes-a8a34110/)
 
-### Reza Rahman
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** RR
-- **Photo:** https://avatars.githubusercontent.com/u/3622346?v=4
-- **Role:** Jakarta Agentic AI project lead at Payara/Azul, Jakarta EE Ambassadors founder
+### Reza Rahman (Java Champion)
+- **Bio:** Jakarta Agentic AI project lead at Payara/Azul, Jakarta EE Ambassadors founder
 - **Links:** [GitHub](https://github.com/m-reza-rahman) · [LinkedIn](https://www.linkedin.com/in/javareza) · [Website](https://reza-rahman.me)
 
 ### K. Siva Prasad Reddy
-
-- **Badge:** Person
-- **Initials:** SR
-- **Photo:** https://avatars.githubusercontent.com/u/542428?v=4
-- **Role:** Developer Advocate at JetBrains, author of *Beginning Spring Boot 3*
+- **Bio:** Developer Advocate at JetBrains, author of Beginning Spring Boot 3
 - **Links:** [@sivalabs](https://twitter.com/sivalabs) · [GitHub](https://github.com/sivaprasadreddy) · [LinkedIn](https://in.linkedin.com/in/ksivaprasadreddy) · [YouTube](https://youtube.com/sivalabs) · [Blog](https://sivalabs.in)
 
-### Jennifer Reif
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** JR
-- **Photo:** https://avatars.githubusercontent.com/u/14850786?v=4
-- **Role:** Developer Advocate at Neo4j
+### Jennifer Reif (Java Champion)
+- **Bio:** Developer Advocate at Neo4j
 - **Links:** [@JMHReif](https://twitter.com/JMHReif) · [GitHub](https://github.com/JMHReif) · [LinkedIn](https://www.linkedin.com/in/jmhreif/) · [Website](https://jmhreif.com)
 
-### Victor Rentea
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** VR
-- **Photo:** https://avatars.githubusercontent.com/u/12481094?v=4
-- **Role:** Independent trainer and consultant; runs a full-day "Agentic Engineering" workshop covering MCP, context/prompt engineering, and multi-agent orchestration for Java teams, and speaks on AI-augmented engineering at Java conferences
+### Victor Rentea (Java Champion)
+- **Bio:** Independent trainer and consultant; runs a full-day "Agentic Engineering" workshop covering MCP, context/prompt engineering, and multi-agent orchestration for Java teams, and speaks on AI-augmented engineering at Java conferences
 - **Links:** [@victorrentea](https://x.com/victorrentea) · [GitHub](https://github.com/victorrentea) · [LinkedIn](https://ro.linkedin.com/in/victor-rentea-trainer) · [Website](https://victorrentea.ro/)
 
-### Baruch Sadogursky
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** BS
-- **Photo:** https://avatars.githubusercontent.com/u/247332?v=4
-- **Role:** Developer Advocate at Tessl, co-author of *Liquid Software* and *DevOps Tools for Java Developers*
+### Baruch Sadogursky (Java Champion)
+- **Bio:** Developer Advocate at Tessl, co-author of Liquid Software and DevOps Tools for Java Developers
 - **Links:** [@jbaruch](https://twitter.com/jbaruch) · [Bluesky](https://bsky.app/profile/jbaru.ch) · [GitHub](https://github.com/jbaruch) · [LinkedIn](https://www.linkedin.com/in/jbaruch/) · [Website](https://speaking.jbaru.ch)
 
 ### Timo Salm
-
-- **Badge:** Person
-- **Initials:** TS
-- **Photo:** https://avatars.githubusercontent.com/u/52704922?v=4
-- **Role:** Principal Solutions Engineer, VMware Tanzu at Broadcom; frequent conference speaker comparing Java agentic-AI frameworks (Spring AI, LangChain4j, Embabel)
+- **Bio:** Principal Solutions Engineer, VMware Tanzu at Broadcom; frequent conference speaker comparing Java agentic-AI frameworks (Spring AI, LangChain4j, Embabel)
 - **Links:** [@salmto](https://twitter.com/salmto) · [GitHub](https://github.com/timosalm) · [LinkedIn](https://www.linkedin.com/in/timosalm)
 
-### Otavio Santana
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** OS
-- **Photo:** https://avatars.githubusercontent.com/u/863011?v=4
-- **Role:** Jakarta Data/Jakarta NoSQL spec lead, Eclipse JNoSQL creator, writes on building AI agents with Jakarta EE and LangChain4j
+### Otavio Santana (Java Champion)
+- **Bio:** Jakarta Data/Jakarta NoSQL spec lead, Eclipse JNoSQL creator, writes on building AI agents with Jakarta EE and LangChain4j
 - **Links:** [@otaviojava](https://twitter.com/otaviojava) · [GitHub](https://github.com/otaviojava) · [LinkedIn](https://www.linkedin.com/in/otaviojava/) · [Website](https://otaviojava.com/) · [YouTube](https://www.youtube.com/@otaviojava)
 
-### Oleg Šelajev
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** OŠ
-- **Photo:** https://avatars.githubusercontent.com/u/426039?v=4
-- **Role:** Developer Relations Lead for AI — Docker
+### Oleg Šelajev (Java Champion)
+- **Bio:** Developer Relations Lead for AI — Docker
 - **Links:** [@shelajev](https://twitter.com/shelajev) · [GitHub](https://github.com/shelajev) · [LinkedIn](https://www.linkedin.com/in/shelajev/)
 
-### Zoran Sevarac
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** ZS
-- **Photo:** https://avatars.githubusercontent.com/u/158153?v=4
-- **Role:** Associate Professor, University of Belgrade; creator of Deep Netts and Neuroph, pure-Java deep learning libraries, and JSR-381 (Visual Recognition API) co-lead
+### Zoran Sevarac (Java Champion)
+- **Bio:** Associate Professor, University of Belgrade; creator of Deep Netts and Neuroph, pure-Java deep learning libraries, and JSR-381 (Visual Recognition API) co-lead
 - **Links:** [GitHub](https://github.com/sevarac) · [LinkedIn](https://www.linkedin.com/in/zoran-sevarac-phd-49a9a411/) · [Website](https://www.zoransevarac.com/)
 
 ### Bartosz Sorrentino
-
-- **Badge:** Person
-- **Initials:** BS
-- **Photo:** https://avatars.githubusercontent.com/u/301596?v=4
-- **Role:** LangGraph4j creator, Principal Software Architect
+- **Bio:** LangGraph4j creator, Principal Software Architect
 - **Links:** [@bsorrentinoJ](https://twitter.com/bsorrentinoJ) · [GitHub](https://github.com/bsorrentino) · [LinkedIn](https://www.linkedin.com/in/bartolomeosorrentino/)
 
-### Alex Soto Bueno
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** AS
-- **Photo:** https://avatars.githubusercontent.com/u/1517153?v=4
-- **Role:** Director of Developer Experience — Red Hat, co-author of "AI Agents with Java" (O'Reilly)
+### Alex Soto Bueno (Java Champion)
+- **Bio:** Director of Developer Experience — Red Hat, co-author of "AI Agents with Java" (O'Reilly)
 - **Links:** [@alexsotob](https://twitter.com/alexsotob) · [GitHub](https://github.com/lordofthejars) · [Blog](https://www.lordofthejars.com)
 
-### Venkat Subramaniam
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** VS
-- **Photo:** https://avatars.githubusercontent.com/u/5804?v=4
-- **Role:** Founder of Agile Developer, creator of the dev2next and Arc of AI conferences, award-winning author and instructor at the University of Houston
+### Venkat Subramaniam (Java Champion)
+- **Bio:** Founder of Agile Developer, creator of the dev2next and Arc of AI conferences, award-winning author and instructor at the University of Houston
 - **Links:** [@venkat_s](https://twitter.com/venkat_s) · [Bluesky](https://bsky.app/profile/venkats.bsky.social) · [GitHub](https://github.com/venkats) · [LinkedIn](https://www.linkedin.com/in/vsubramaniam/)
 
 ### Christian Tzolov
-
-- **Badge:** Person
-- **Initials:** CT
-- **Photo:** https://avatars.githubusercontent.com/u/1351573?v=4
-- **Role:** Spring AI lead, MCP Java SDK founder, Spring team at Broadcom
+- **Bio:** Spring AI lead, MCP Java SDK founder, Spring team at Broadcom
 - **Links:** [@christzolov](https://twitter.com/christzolov) · [Bluesky](https://bsky.app/profile/tzolov.bsky.social) · [GitHub](https://github.com/tzolov) · [LinkedIn](https://www.linkedin.com/in/tzolov/)
 
-### Dan Vega
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** DV
-- **Photo:** https://avatars.githubusercontent.com/u/349507?v=4
-- **Role:** Spring Developer Advocate, YouTube educator
+### Dan Vega (Java Champion)
+- **Bio:** Spring Developer Advocate, YouTube educator
 - **Links:** [@therealdanvega](https://twitter.com/therealdanvega) · [Bluesky](https://bsky.app/profile/danvega.dev) · [GitHub](https://github.com/danvega) · [LinkedIn](https://www.linkedin.com/in/danvega/) · [Blog](https://www.danvega.dev/)
 
 ### Dmitry Vinnik
-
-- **Badge:** Person
-- **Initials:** DV
-- **Photo:** https://avatars.githubusercontent.com/u/12485205?v=4
-- **Role:** Lead Developer Advocate at Meta
+- **Bio:** Lead Developer Advocate at Meta
 - **Links:** [@DmitryVinnik](https://twitter.com/DmitryVinnik) · [GitHub](https://github.com/dmitryvinn) · [LinkedIn](https://www.linkedin.com/in/dmitry-vinnik/) · [Blog](https://dvinnik.dev/)
 
-### Thomas Vitale
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** TV
-- **Photo:** https://avatars.githubusercontent.com/u/8523418?v=4
-- **Role:** Spring AI Lead Contributor, creator of Arconia, author of *Cloud Native Spring in Action*
+### Thomas Vitale (Java Champion)
+- **Bio:** Spring AI Lead Contributor, creator of Arconia, author of Cloud Native Spring in Action
 - **Links:** [@vitalethomas](https://x.com/vitalethomas) · [Bluesky](https://bsky.app/profile/thomasvitale.com) · [GitHub](https://github.com/ThomasVitale) · [LinkedIn](https://www.linkedin.com/in/vitalethomas/) · [Website](https://www.thomasvitale.com)
 
-### Craig Walls
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** CW
-- **Photo:** https://avatars.githubusercontent.com/u/167926?v=4
-- **Role:** Author of *Spring AI in Action*
+### Craig Walls (Java Champion)
+- **Bio:** Author of Spring AI in Action
 - **Links:** [@habuma](https://twitter.com/habuma) · [Bluesky](https://bsky.app/profile/habuma.com) · [GitHub](https://github.com/habuma) · [LinkedIn](https://www.linkedin.com/in/habuma)
 
-### James Ward
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** JW
-- **Photo:** https://avatars.githubusercontent.com/u/65043?v=4
-- **Role:** Developer Advocate — Java, Kotlin, Cloud, AI
+### James Ward (Java Champion)
+- **Bio:** Developer Advocate — Java, Kotlin, Cloud, AI
 - **Links:** [@_JamesWard](https://twitter.com/_jamesward) · [Bluesky](https://bsky.app/profile/jamesward.com) · [GitHub](https://github.com/jamesward) · [LinkedIn](https://www.linkedin.com/in/jamesward) · [Blog](https://jamesward.com)
 
 ### Pascal Wilbrink
-
-- **Badge:** Person
-- **Initials:** PW
-- **Photo:** https://avatars.githubusercontent.com/u/5970214?v=4
-- **Role:** Senior Software Developer — OpenValue; creator of the Spring AI AG-UI Java SDK, bringing the AG-UI protocol to Java/Spring AI
+- **Bio:** Senior Software Developer at OpenValue; creator of the Spring AI AG-UI Java SDK, bringing the AG-UI protocol to Java/Spring AI
 - **Links:** [GitHub](https://github.com/pascalwilbrink) · [Website](https://pascalwilbrink.github.io)
-
----
 
 ## FAQ
 
-Frequently asked questions about AI development on the JVM. Rendered as a Q&A list. Include matching `FAQPage` structured data in the page `<head>`.
+Frequently asked questions about AI development on the JVM.
 
 ### What is the best Java framework for building AI agents?
-The most popular choices are Spring AI and LangChain4j. Spring AI is ideal if you're already in the Spring ecosystem, offering portable abstractions across 20+ model providers. LangChain4j provides a standalone library with three levels of abstraction, from low-level prompts to high-level AI Services. Other options include Google ADK for Java, Embabel, and Akka Agents — each with different strengths for specific use cases.
+The most popular choices are [Spring AI and LangChain4j](#frameworks). Spring AI is ideal if you’re already in the Spring ecosystem, offering portable abstractions across 20+ model providers. LangChain4j provides a standalone library with three levels of abstraction, from low-level prompts to high-level AI Services. Other options include Google ADK for Java, Embabel, and Akka Agents — each with different strengths for specific use cases.
 
 ### Can Java run LLMs locally?
-Yes. Projects like Jlama and GPULlama3.java run Llama, Mistral, and other models directly on the JVM. Jlama uses Java's Vector API for SIMD-accelerated inference on CPU, while GPULlama3.java leverages TornadoVM for GPU acceleration. For production deployments, ONNX Runtime Java supports hardware-accelerated inference across CUDA, DirectML, and CoreML.
+Yes. Projects like [Jlama and GPULlama3.java](#inference) run Llama, Mistral, and other models directly on the JVM. Jlama uses Java’s Vector API for SIMD-accelerated inference on CPU, while GPULlama3.java leverages TornadoVM for GPU acceleration. For production deployments, ONNX Runtime Java supports hardware-accelerated inference across CUDA, DirectML, and CoreML.
 
 ### What is MCP and how does it work with Java?
 The Model Context Protocol (MCP) is an open standard that lets AI assistants interact with external tools and data sources. The official MCP Java SDK, maintained by the Spring AI team, provides both client and server implementations with sync/async support and multiple transports (STDIO, Streamable HTTP; SSE deprecated as of 2.0). Helidon MCP and several frameworks also offer MCP support.
@@ -1173,131 +802,110 @@ The Model Context Protocol (MCP) is an open standard that lets AI assistants int
 ### Is Kotlin supported by Java AI frameworks?
 Yes. Most Java AI frameworks run on any JVM language. Embabel is written in Kotlin with full Java interop, Koog from JetBrains is a Kotlin-native agent framework, and Tracy provides AI observability for Kotlin. LangChain4j and Spring AI work seamlessly from Kotlin code.
 
----
-
 ## Recent & Noteworthy Content, Communities, and Resources
 
-### Java Conferences Tracker
+Talks, tutorials, books, and communities for learning AI development on the JVM.
 
+### Java Conferences Tracker
 - **Badge:** Community
 - **Description:** Community-maintained calendar of all Java conferences worldwide
-- **Links:** [Website](https://javaconferences.org/)
+- **Links:** [Java Conferences Tracker](https://javaconferences.org/)
 
 ### Java Relevance in the AI Era
-
 - **Badge:** Blog
 - **Description:** RedMonk analysis of Java's position as agent frameworks emerge
-- **Links:** [Article](https://redmonk.com/jgovernor/java-relevance-in-the-ai-era-agent-frameworks-emerge/)
+- **Links:** [Java Relevance in the AI Era](https://redmonk.com/jgovernor/java-relevance-in-the-ai-era-agent-frameworks-emerge/)
 
 ### Awesome Spring AI
-
 - **Badge:** Resource
 - **Description:** Curated list of Spring AI resources, tools, and tutorials
-- **Links:** [GitHub](https://github.com/spring-ai-community/awesome-spring-ai)
+- **Links:** [Awesome Spring AI](https://github.com/spring-ai-community/awesome-spring-ai)
 
 ### Spring AI in Action (Manning)
-
 - **Badge:** Book
 - **Description:** Book by Craig Walls — comprehensive guide to building AI apps with Spring
-- **Links:** [Book](https://www.manning.com/books/spring-ai-in-action)
+- **Links:** [Spring AI in Action (Manning)](https://www.manning.com/books/spring-ai-in-action)
 
 ### Understanding LangChain4j
-
 - **Badge:** Book
 - **Description:** Book by Antonio Goncalves — explore the fundamentals of AI, learn the history and evolution of AI models, and understand the core concepts of LangChain4j
-- **Links:** [Book](https://www.amazon.com/Understanding-LangChain4j-2nd-agoncal-fascicles-ebook/dp/B0FDQVSLXK)
+- **Links:** [Understanding LangChain4j](https://www.amazon.com/Understanding-LangChain4j-2nd-agoncal-fascicles-ebook/dp/B0FDQVSLXK)
 
 ### AI Agents with Java (O'Reilly)
-
 - **Badge:** Book
-- **Description:** Early-release O'Reilly book by Java Champions Alex Soto Bueno, Markus Eisele, and Mario Fusco — building long-running, stateful agents on the JVM with zero-trust security, RAG, and multi-agent coordination using Quarkus, LangChain4j, and LangGraph4j
-- **Links:** [Book](https://www.oreilly.com/library/view/ai-agents-with/0642572245856/)
+- **Description:** Early-release book by Java Champions Alex Soto Bueno, Markus Eisele, and Mario Fusco — building long-running, stateful agents on the JVM with zero-trust security, RAG, and multi-agent coordination
+- **Links:** [AI Agents with Java (O'Reilly)](https://www.oreilly.com/library/view/ai-agents-with/0642572245856/)
 
 ### Applied AI for Enterprise Java Development (O'Reilly)
-
 - **Badge:** Book
 - **Description:** Book by Alex Soto Bueno, Markus Eisele, and Natale Vinto — prompt engineering, RAG, guardrails, fault tolerance, and enterprise AI architecture using Quarkus, LangChain4j, and vector stores
-- **Links:** [Book](https://www.oreilly.com/library/view/applied-ai-for/9781098174491/)
+- **Links:** [Applied AI for Enterprise Java Development (O'Reilly)](https://www.oreilly.com/library/view/applied-ai-for/9781098174491/)
 
 ### Production LangChain4j — Inside.java
-
 - **Badge:** Resource
 - **Description:** Advanced RAG, agentic workflows, and production tips from Devoxx Belgium
-- **Links:** [Article](https://inside.java/2026/02/01/devoxxbelgium-production-langchain4j/)
+- **Links:** [Production LangChain4j — Inside.java](https://inside.java/2026/02/01/devoxxbelgium-production-langchain4j/)
 
 ### Google ADK Java Codelab
-
 - **Badge:** Resource
 - **Description:** Hands-on: build AI agents in Java with Google's ADK
-- **Links:** [Codelab](https://codelabs.developers.google.com/adk-java-getting-started)
+- **Links:** [Google ADK Java Codelab](https://codelabs.developers.google.com/adk-java-getting-started)
 
 ### Devoxx YouTube
-
 - **Badge:** Videos
 - **Description:** Thousands of conference talks on Java, AI, cloud, and architecture
-- **Links:** [YouTube](https://www.youtube.com/@DevoxxForever)
+- **Links:** [Devoxx YouTube](https://www.youtube.com/@DevoxxForever)
 
 ### Coffee + Software
-
 - **Badge:** Videos
 - **Description:** Spring ecosystem, AI integration, and Java community
-- **Links:** [YouTube](https://youtube.com/@coffeesoftware)
+- **Links:** [Coffee + Software](https://youtube.com/@coffeesoftware)
 
 ### Foojay Podcast: Java AI Revolution
-
 - **Badge:** Resource
 - **Description:** Agents, MCP, graph databases — developers navigate the AI revolution
-- **Links:** [Podcast](https://foojay.io/today/foojay-podcast-86/)
+- **Links:** [Foojay Podcast: Java AI Revolution](https://foojay.io/today/foojay-podcast-86/)
 
-### Building Java AI Agents with Spring AI (AWS Workshop)
-
+### Building Java AI Agents with Spring AI (AWS)
 - **Badge:** Workshop
 - **Description:** Hands-on AWS workshop for building intelligent AI agents with Spring AI and AWS services, including deployment to EKS
-- **Links:** [Workshop](https://catalog.workshops.aws/java-spring-ai-agents/en-US)
+- **Links:** [Building Java AI Agents with Spring AI (AWS)](https://catalog.workshops.aws/java-spring-ai-agents/en-US)
 
-## AI & Java on Serverless Office Hours
+### AI & Java on Serverless Office Hours
 - **Badge:** Livestream
 - **Description:** James Ward and Julian Wood explore building AI-powered Java apps — MCP integration, agent architectures with AgentCore, GraalVM optimization for AI workloads, and secure auth patterns for AI services on serverless
-- **Links:** https://www.youtube.com/watch?v=my2bQtHBUeY
+- **Links:** [AI & Java on Serverless Office Hours](https://www.youtube.com/watch?v=my2bQtHBUeY)
 
 ### Java for an AI World — JavaOne 2026 Opening Keynote
-
 - **Badge:** Videos
 - **Description:** Opening keynote of JavaOne 2026, featuring Rod Johnson, Josh Long, and engineering leads from Oracle, Microsoft, NVIDIA, JetBrains, and Uber on Java's AI direction, including the GitHub Copilot SDK for Java
-- **Links:** https://www.youtube.com/watch?v=3fLCOqpIfI0
+- **Links:** [Java for an AI World — JavaOne 2026 Opening Keynote](https://www.youtube.com/watch?v=3fLCOqpIfI0)
 
 ### Bootiful Spring AI — Josh Long & James Ward @ Spring I/O 2026
-
 - **Badge:** Videos
 - **Description:** Talk from Spring I/O 2026 in Barcelona demystifying AI integration with Spring Boot — agentic patterns, Spring AI, and MCP integration
-- **Links:** https://www.youtube.com/watch?v=nHnKReitDXc
+- **Links:** [Bootiful Spring AI — Josh Long & James Ward @ Spring I/O 2026](https://www.youtube.com/watch?v=nHnKReitDXc)
 
 ### Java and AI in 2026 and Beyond — James Ward Interview
-
 - **Badge:** Videos
 - **Description:** 68-minute interview with James Ward on the Code With Ease channel, recorded at GIDS Bangalore — the Java AI landscape from Spring AI, LangChain4j, Koog, and Embabel to MCP, agent memory, RAG vs tools vs skills, and production deployment with AWS AgentCore
-- **Links:** https://www.youtube.com/watch?v=-TWXNYRE0Q8
+- **Links:** [Java and AI in 2026 and Beyond — James Ward Interview](https://www.youtube.com/watch?v=-TWXNYRE0Q8)
 
 ### Liberty LangChain4j Workshop
-
 - **Badge:** Workshop
 - **Description:** Hands-on, self-paced Open Liberty workshop that progresses from a simple chatbot to agentic systems using LangChain4j — prompt engineering, streaming, RAG, tool calling, MCP, guardrails/observability, and multi-agent supervisor patterns
 - **Links:** [Workshop](https://openliberty.github.io/liberty-workshop-langchain4j/) · [Blog](https://openliberty.io/blog/2026/07/10/liberty-langchain4j-workshop.html)
 
 ### ScarfBench
-
 - **Badge:** Resource
-- **Description:** IBM Research's open benchmark for evaluating AI agents on enterprise Java framework migration — 102 applications and 204 tasks (~1,331 tests) covering Jakarta EE, Quarkus, and Spring, with a public leaderboard.
+- **Description:** IBM Research's open benchmark for evaluating AI agents on enterprise Java framework migration — 102 applications and 204 tasks (~1,331 tests) covering Jakarta EE, Quarkus, and Spring, with a public leaderboard
 - **Links:** [GitHub](https://github.com/scarfbench/benchmark) · [Announcement](https://www.ibm.com/new/announcements/scarfbench-a-public-benchmark-for-java-framework-migration)
 
 ### Kotlin Benchmark for AI Coding Agents
-
 - **Badge:** Resource
 - **Description:** JetBrains' open benchmark for evaluating AI coding agents on real-world Kotlin tasks — 105 issues drawn from active open-source Kotlin repositories including ktlint, detekt, and ort, each requiring the agent to read an issue, navigate the project, and produce a patch that passes the project's tests. Public leaderboard, built on the Multi-SWE-bench methodology.
 - **Links:** [Leaderboard](https://kotlinlang.org/benchmark/) · [GitHub](https://github.com/Kotlin/kotlin-swe-bench) · [Announcement](https://blog.jetbrains.com/kotlin/2026/07/introducing-the-kotlin-benchmark-evaluate-ai-coding-agents-on-real-world-kotlin-tasks/)
 
 ---
 
-## Footer
-
-"AI4JVM — Curating the Java AI ecosystem. Contributions welcome on [GitHub](https://github.com/jamesward/ai4jvm)."
+AI4JVM — Curating the Java AI ecosystem. Contributions welcome on [GitHub](https://github.com/jamesward/ai4jvm).

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # AI4JVM
 
-> The curated guide to AI on the JVM — Spring AI, LangChain4j, Kotlin AI frameworks, inference engines, and more. Compare Java AI agent frameworks, find learning resources, and follow key people building the Java AI ecosystem.
+> The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.
 
 AI4JVM is a single-page, human-curated directory covering agent frameworks, inference engines, code-assistant integrations, key people, and learning resources for building AI applications on the JVM (Java, Kotlin, and other JVM languages). Content is governed by an editorial policy: entries must be specific to Java/JVM developers (not general AI resources) and actively maintained; see the Contributing link below for the full criteria.
 
@@ -16,6 +16,7 @@ AI4JVM is a single-page, human-curated directory covering agent frameworks, infe
 
 ## Optional
 
+- [Full site content](https://ai4jvm.com/llms-full.txt): Every section and every entry from the site as plain Markdown — fetch this instead of parsing the HTML.
 - [Contributing guidelines](https://github.com/jamesward/ai4jvm/blob/main/CONTRIBUTING.md): Editorial policy for what gets included on the site and how to submit a resource.
 - [Full site content spec](https://github.com/jamesward/ai4jvm/blob/main/SPEC.md): Machine-readable source of truth for every entry on the site.
 - [Source repository](https://github.com/jamesward/ai4jvm): HTML source and site generation process.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-19</lastmod>
+    <lastmod>2026-08-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
Scheduled site refresh. All new entries were verified by fetching the actual pages (never inferred from URLs) and checked against the `CONTRIBUTING.md` policy — JVM-specific, actively maintained, relevant to a broad slice of Java developers.

## Content

**News** (8 items, newest first)
| Item | Source |
|---|---|
| MCP Java SDK 2.0.1 | GitHub release, Aug 19 |
| Jakarta Agentic AI Hits Its First Milestone | Foojay, Aug 5 |
| Under the HAT: Empowering GPU Acceleration for Java | inside.java, Jul 30 |
| GPULlama3.java 1.0.0 | GitHub release, Jul 28 |
| Micronaut LangChain4j 2.2.0 | GitHub release, Jul 24 |
| JetBrains Air Adds Java and Kotlin Code Intelligence | JetBrains blog, Jul |
| Self-Correcting Structured Output in Spring AI 2.0 | spring.io, Jun 23 |
| Tool Calling in Spring AI 2.0: A Composable, Agentic Architecture | spring.io, Jun 15 |

**Frameworks & Libraries**
- **Micronaut LangChain4j** — the site listed the Quarkus, Helidon, and CDI LangChain4j integrations but not Micronaut's, despite it shipping four releases since May.
- **Spring AI A2A** — Spring Boot binding for the A2A protocol; the site had the A2A Java SDK and its Jakarta server variant but no Spring integration.
- **Spring AI Session** — event-sourced conversation memory with turn-aware compaction.
- **Spring AI Playground** — local execution layer for agent tools with a deny-first sandbox.

**Resources**
- **Kotlin Benchmark for AI Coding Agents** (JetBrains) — 105 real issues from ktlint, detekt, and ort. Pairs with the existing ScarfBench entry.

**Updated**
- The GPULlama3.java card linked only a 2025 InfoQ article. It now links GitHub and notes the 1.0.0 Maven Central release.

## SEO

Audited with the [SearchFit SEO](https://github.com/searchfit/searchfit-seo) skill's on-page, technical, and schema-markup checklists.

- **Title 83 → 62 chars, meta description 224 → 153 chars.** Both were over the length Google renders and were being truncated in results. Open Graph and Twitter Card kept in sync.
- **`WebSite` schema** gains `@id`, `inLanguage`, and an `about` list naming the site's core topics; a new **`CollectionPage`** schema carries `dateModified`, tied to the sitemap's `lastmod`.
- **`ItemList` coverage extended** from Frameworks only to Code Assistants (23), Inference & Training (10), and People to Follow (57 nested `Person` entries) — the whole directory is now machine-readable, not a quarter of it. All lists were generated from the rendered cards so they can't drift.

## Accessibility

Person names were `h4` elements sitting directly under an `h2`, a skipped heading level that Lighthouse flagged as a violation. They're now `h3`, matching every other card on the page. The CSS selector moved with them, and the section was re-rendered in Chromium to confirm it looks identical.

## Agent readiness

Checked against the categories [isitagentready.com](https://isitagentready.com) scans. `robots.txt`, sitemap, AI-bot rules, and Content Signals were already in place; the gap was content accessibility.

- **New `/llms-full.txt`** — the complete directory as plain Markdown (7 sections, 177 entries). Agents that want the whole catalog fetch one 93 KB Markdown file instead of parsing 190 KB of HTML. Linked from the document head via `rel="alternate" type="text/markdown"`, and from `llms.txt`.

Two other checks the scanner looks for — `Link:` response headers and true `Accept: text/markdown` content negotiation — need CloudFront configuration rather than repo changes, so they're out of scope here.

## Performance

The PageSpeed Insights API was over its daily quota, so this was measured with Lighthouse directly (mobile, `--form-factor=mobile`).

- **Google Analytics moved to the end of the document head.** It sat above the charset meta tag and the title, delaying parsing of everything critical. `charset` is now at byte 42 instead of 345.
- Added a `dns-prefetch` fallback alongside the existing `preconnect` for the avatar origin.

| | Before | After |
|---|---|---|
| Performance | 98 | 98 |
| Accessibility | 98 | **100** |
| Best Practices | 96 | 96 |
| SEO | 100 | 100 |

Run against a local server, so the two remaining flags are test-harness artifacts rather than site issues: `document-latency` reflects the local server not gzipping (production serves 38 KB gzipped via CloudFront), and `errors-in-console` is the sandbox proxy blocking the GA request.

## Verification

- All new links fetched and confirmed live.
- `index.html` parses with no mismatched or unclosed tags; all 7 JSON-LD blocks parse as valid JSON.
- Rendered in Chromium and screenshotted — 116 cards, 57 people, layout unchanged.

## Spec

`SPEC.md` was updated first, then `index.html`, per `AGENTS.md`. The SEO section now records the title/description length limits, the charset-first and analytics-last ordering, the full structured-data inventory, the no-skipped-headings rule, and the `llms-full.txt` requirement, so future regens preserve all of this.

## Not included

- **BoxLang AI** — capable, actively maintained, but BoxLang is unlikely to clear the ">10% of Java developers" bar in `CONTRIBUTING.md`. Flagging for your call rather than adding it.
- **Spring AI 2.0.1** — a `v2.0.1` tag exists but there's no announcement post yet, so it isn't verifiable. Worth revisiting in a few days.
- **Deep Java Library (DJL)** — last release was Dec 2025, roughly eight months ago. Not enough evidence to mark it unmaintained, so it's unchanged, but it may deserve a status note if the next refresh finds it still quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DytgMFfW4rArJC2uMA49aB