### PR TITLE
Add missing SEO meta tags for search/social conformance

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -16,6 +16,8 @@ AI4JVM is a curated guide to the Java AI ecosystem — a single-page website cov
 - Keep Open Graph and Twitter Card meta tags in sync with the title/description above
 - `<meta charset>` must appear within the first 1024 bytes of the document, so it comes first in `<head>`; the Google Analytics tag goes last, just before `</head>`
 - **Theme color:** `<meta name="theme-color" content="#0f1117">` matching the page background
+- `<meta name="robots" content="index, follow">` and `<meta name="author" content="James Ward">`
+- `og:image:type` (`image/png`) alongside the existing `og:image` dimensions/alt tags; `twitter:site` (`@_jamesward`) and `twitter:image:alt` alongside the existing Twitter Card tags
 
 ### Structured Data (JSON-LD)
 - Include `WebSite` schema with `@id`, `inLanguage`, `publisher`, and an `about` list naming the site's core topics (Java, Kotlin, JVM, AI, LLMs, MCP)

--- a/index.html
+++ b/index.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>AI4JVM — Java AI Frameworks, LLM Inference &amp; JVM Tools</title>
   <meta name="description" content="The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.">
+  <meta name="robots" content="index, follow">
+  <meta name="author" content="James Ward">
   <meta name="theme-color" content="#0f1117">
   <link rel="canonical" href="https://ai4jvm.com/">
   <link rel="icon" href="/favicon.ico" sizes="16x16 32x32 48x48">
@@ -25,14 +27,17 @@
   <meta property="og:site_name" content="AI4JVM">
   <meta property="og:locale" content="en_US">
   <meta property="og:image" content="https://ai4jvm.com/og-image.png">
+  <meta property="og:image:type" content="image/png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:image:alt" content="AI4JVM — Java &amp; JVM AI Ecosystem Guide">
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@_jamesward">
   <meta name="twitter:title" content="AI4JVM — Java AI Frameworks, LLM Inference &amp; JVM Tools">
   <meta name="twitter:description" content="The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.">
   <meta name="twitter:image" content="https://ai4jvm.com/og-image.png">
+  <meta name="twitter:image:alt" content="AI4JVM — Java &amp; JVM AI Ecosystem Guide">
   <!-- Structured Data -->
   <script type="application/ld+json">
   {
@@ -69,7 +74,7 @@
     "description": "The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.",
     "isPartOf": {"@id": "https://ai4jvm.com/#website"},
     "inLanguage": "en-US",
-    "dateModified": "2026-08-22",
+    "dateModified": "2026-08-23",
     "primaryImageOfPage": {
       "@type": "ImageObject",
       "url": "https://ai4jvm.com/og-image.png",

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-22</lastmod>
+    <lastmod>2026-08-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Added `<meta name="robots" content="index, follow">` and `<meta name="author" content="James Ward">` to `<head>`
- Added `og:image:type` and `twitter:site` / `twitter:image:alt` to round out the existing Open Graph / Twitter Card tags
- Documented the new tags in `SPEC.md`'s Head & Meta section (source of truth) and bumped `dateModified` / `sitemap.xml`'s `<lastmod>` to match

## Audit notes
I reviewed the site against its own governance policy in `SPEC.md` (SEO, Agent Friendliness, Performance sections) plus the isitagentready.com and PageSpeed Insights criteria:

- **SEO**: title/description length, canonical, JSON-LD (WebSite/CollectionPage/ItemList ×4/FAQPage), heading hierarchy, section intros, and sitemap/robots.txt all already conform. Added the handful of standard meta tags above that weren't yet covered.
- **Agent friendliness**: `robots.txt` already has the `Content-Signal` directive and an explicit allow-list for AI crawlers/assistants; `/llms.txt` and `/llms-full.txt` are in place and linked via `<link rel="alternate">`. Newer conventions like Link-header content negotiation and DNS-AID require custom HTTP response headers, which aren't available on GitHub Pages static hosting (no `_headers`/edge-function support), so they aren't implementable without a change in hosting — I left those out rather than adding something that wouldn't actually work.
- **Performance**: the site already follows its documented performance rules (no web fonts, sized/lazy-loaded avatar images, `preconnect`/`dns-prefetch`, single inline `<style>` block, deferred Google Analytics tag). I wasn't able to pull a live PageSpeed Insights score — the API's daily quota is exhausted for this environment's project — so this is a manual audit against Lighthouse's usual criteria rather than a fresh score.
- **Content governance**: spot-checked the News section for staleness (3-month window) and recent Java AI releases (Spring AI, LangChain4j, MCP Java SDK, Quarkus LangChain4j, Koog, A2A Java SDK) — nothing new since the Aug 21 entries already listed, and nothing currently listed is past the 3-month cutoff.

## Test plan
- [x] Reviewed the diff for well-formed HTML (no unclosed/duplicate tags)
- [ ] Manual visual check of the page once deployed (no visible changes expected — all changes are in `<head>`)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149bRLp8rLLwWhwiAaoFPqY)_