### PR TITLE
Add Spring AI - watsonx.ai for IBM watsonx.ai Spring AI Integration

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -387,6 +387,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** IBM's official Java SDK for the watsonx.ai enterprise AI platform. Chat completions, streaming, tool calling, embeddings, text classification/extraction/detection, reranking, and time-series forecasting, for both IBM Cloud and on-premises (CP4D) deployments. Integrates with LangChain4j, Quarkus, and Apache Camel.
 - **Links:** [GitHub](https://github.com/IBM/watsonx-ai-java-sdk) · [Docs](https://ibm.github.io/watsonx-ai-java-sdk/)
 
+### Spring AI — watsonx.ai
+- **Badge:** SDK
+- **Description:** Official Spring AI integration for IBM watsonx.ai. Spring Boot auto-configuration for chat (IBM Granite, Meta Llama, Mistral AI), embeddings, content moderation (HAP, PII, Granite Guardian), and document reranking via Spring AI's portable abstractions. Supports streaming, function calling, and reactive programming with WebFlux.
+- **Links:** [Docs](https://spring-ai-community.github.io/spring-ai-watsonx-ai) · [GitHub](https://github.com/spring-ai-community/spring-ai-watsonx-ai)
+
 ### SAP AI SDK for Java
 - **Badge:** SDK
 - **Description:** SAP's official Java SDK for integrating generative AI into enterprise applications via SAP AI Core and the Generative AI Hub. Orchestration service integration, prompt templating, grounding, data masking, content filtering, and Spring AI compatibility.

--- a/index.html
+++ b/index.html
@@ -134,25 +134,26 @@
       {"@type": "ListItem", "position": 42, "name": "OpenAI Java SDK", "url": "https://github.com/openai/openai-java"},
       {"@type": "ListItem", "position": 43, "name": "Google Gen AI Java SDK", "url": "https://github.com/googleapis/java-genai"},
       {"@type": "ListItem", "position": 44, "name": "IBM watsonx.ai Java SDK", "url": "https://github.com/IBM/watsonx-ai-java-sdk"},
-      {"@type": "ListItem", "position": 45, "name": "SAP AI SDK for Java", "url": "https://github.com/SAP/ai-sdk-java"},
-      {"@type": "ListItem", "position": 46, "name": "Tiberius", "url": "https://github.com/tiberius-security/tiberius"},
-      {"@type": "ListItem", "position": 47, "name": "Ollama4j", "url": "https://github.com/ollama4j/ollama4j"},
-      {"@type": "ListItem", "position": 48, "name": "Cohere Java SDK", "url": "https://github.com/cohere-ai/cohere-java"},
-      {"@type": "ListItem", "position": 49, "name": "kyo-ai", "url": "https://github.com/getkyo/kyo/tree/main/kyo-ai"},
-      {"@type": "ListItem", "position": 50, "name": "zio-bedrock-converse", "url": "https://github.com/jamesward/zio-bedrock-converse"},
-      {"@type": "ListItem", "position": 51, "name": "zio-http-mcp", "url": "https://github.com/jamesward/zio-http-mcp"},
-      {"@type": "ListItem", "position": 52, "name": "Tachyon", "url": "https://github.com/kpavlov/tachyon"},
-      {"@type": "ListItem", "position": 53, "name": "Solon-AI", "url": "https://github.com/opensolon/solon-ai"},
-      {"@type": "ListItem", "position": 54, "name": "AWS SDK for Java v2 — Bedrock", "url": "https://github.com/aws/aws-sdk-java-v2"},
-      {"@type": "ListItem", "position": 55, "name": "Qdrant Java Client", "url": "https://github.com/qdrant/java-client"},
-      {"@type": "ListItem", "position": 56, "name": "Weaviate Java Client", "url": "https://github.com/weaviate/java-client"},
-      {"@type": "ListItem", "position": 57, "name": "Pinecone Java Client", "url": "https://github.com/pinecone-io/pinecone-java-client"},
-      {"@type": "ListItem", "position": 58, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"},
-      {"@type": "ListItem", "position": 59, "name": "Camel LangChain4j Components", "url": "https://camel.apache.org/components/next/langchain4j-chat-component.html"},
-      {"@type": "ListItem", "position": 60, "name": "Google ADK for Kotlin", "url": "https://adk.dev/"},
-      {"@type": "ListItem", "position": 61, "name": "LLM4S", "url": "https://llm4s.org/"},
-      {"@type": "ListItem", "position": 62, "name": "Agents-Flex", "url": "https://github.com/agents-flex/agents-flex"},
-      {"@type": "ListItem", "position": 63, "name": "Spring AI Alibaba", "url": "https://github.com/alibaba/spring-ai-alibaba"}
+      {"@type": "ListItem", "position": 45, "name": "Spring AI — watsonx.ai", "url": "https://github.com/spring-ai-community/spring-ai-watsonx-ai"},
+      {"@type": "ListItem", "position": 46, "name": "SAP AI SDK for Java", "url": "https://github.com/SAP/ai-sdk-java"},
+      {"@type": "ListItem", "position": 47, "name": "Tiberius", "url": "https://github.com/tiberius-security/tiberius"},
+      {"@type": "ListItem", "position": 48, "name": "Ollama4j", "url": "https://github.com/ollama4j/ollama4j"},
+      {"@type": "ListItem", "position": 49, "name": "Cohere Java SDK", "url": "https://github.com/cohere-ai/cohere-java"},
+      {"@type": "ListItem", "position": 50, "name": "kyo-ai", "url": "https://github.com/getkyo/kyo/tree/main/kyo-ai"},
+      {"@type": "ListItem", "position": 51, "name": "zio-bedrock-converse", "url": "https://github.com/jamesward/zio-bedrock-converse"},
+      {"@type": "ListItem", "position": 52, "name": "zio-http-mcp", "url": "https://github.com/jamesward/zio-http-mcp"},
+      {"@type": "ListItem", "position": 53, "name": "Tachyon", "url": "https://github.com/kpavlov/tachyon"},
+      {"@type": "ListItem", "position": 54, "name": "Solon-AI", "url": "https://github.com/opensolon/solon-ai"},
+      {"@type": "ListItem", "position": 55, "name": "AWS SDK for Java v2 — Bedrock", "url": "https://github.com/aws/aws-sdk-java-v2"},
+      {"@type": "ListItem", "position": 56, "name": "Qdrant Java Client", "url": "https://github.com/qdrant/java-client"},
+      {"@type": "ListItem", "position": 57, "name": "Weaviate Java Client", "url": "https://github.com/weaviate/java-client"},
+      {"@type": "ListItem", "position": 58, "name": "Pinecone Java Client", "url": "https://github.com/pinecone-io/pinecone-java-client"},
+      {"@type": "ListItem", "position": 59, "name": "Testcontainers Ollama Module", "url": "https://java.testcontainers.org/modules/ollama/"},
+      {"@type": "ListItem", "position": 60, "name": "Camel LangChain4j Components", "url": "https://camel.apache.org/components/next/langchain4j-chat-component.html"},
+      {"@type": "ListItem", "position": 61, "name": "Google ADK for Kotlin", "url": "https://adk.dev/"},
+      {"@type": "ListItem", "position": 62, "name": "LLM4S", "url": "https://llm4s.org/"},
+      {"@type": "ListItem", "position": 63, "name": "Agents-Flex", "url": "https://github.com/agents-flex/agents-flex"},
+      {"@type": "ListItem", "position": 64, "name": "Spring AI Alibaba", "url": "https://github.com/alibaba/spring-ai-alibaba"}
     ]
   }
   </script>
@@ -1074,6 +1075,16 @@
         <div class="card-links">
           <a class="icon icon-github" href="https://github.com/IBM/watsonx-ai-java-sdk" title="GitHub"></a>
           <a class="icon icon-web" href="https://ibm.github.io/watsonx-ai-java-sdk/" title="Docs"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-framework">SDK</span>
+        <h3><a href="https://spring-ai-community.github.io/spring-ai-watsonx-ai">Spring AI — watsonx.ai</a></h3>
+        <p>Official Spring AI integration for IBM watsonx.ai. Spring Boot auto-configuration for chat (IBM Granite, Meta Llama, Mistral AI), embeddings, content moderation (HAP, PII, Granite Guardian), and document reranking via Spring AI's portable abstractions. Supports streaming, function calling, and reactive programming with WebFlux.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://spring-ai-community.github.io/spring-ai-watsonx-ai" title="Docs"></a>
+          <a class="icon icon-github" href="https://github.com/spring-ai-community/spring-ai-watsonx-ai" title="GitHub"></a>
         </div>
       </div>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -287,6 +287,11 @@ Open-source frameworks and SDKs for building AI-powered applications on the JVM 
 - **Description:** IBM's official Java SDK for the watsonx.ai enterprise AI platform. Chat completions, streaming, tool calling, embeddings, text classification/extraction/detection, reranking, and time-series forecasting, for both IBM Cloud and on-premises deployments. Integrates with LangChain4j, Quarkus, and Apache Camel.
 - **Links:** [GitHub](https://github.com/IBM/watsonx-ai-java-sdk) · [Docs](https://ibm.github.io/watsonx-ai-java-sdk/)
 
+### Spring AI — watsonx.ai
+- **Badge:** SDK
+- **Description:** Official Spring AI integration for IBM watsonx.ai. Spring Boot auto-configuration for chat (IBM Granite, Meta Llama, Mistral AI), embeddings, content moderation (HAP, PII, Granite Guardian), and document reranking via Spring AI's portable abstractions. Supports streaming, function calling, and reactive programming with WebFlux.
+- **Links:** [Docs](https://spring-ai-community.github.io/spring-ai-watsonx-ai) · [GitHub](https://github.com/spring-ai-community/spring-ai-watsonx-ai)
+
 ### SAP AI SDK for Java
 - **Badge:** SDK
 - **Description:** SAP's official Java SDK for integrating generative AI into enterprise applications via SAP AI Core and the Generative AI Hub. Orchestration service integration, prompt templating, grounding, data masking, content filtering, and Spring AI compatibility.


### PR DESCRIPTION
Adding Spring AI - watsonx.ai as the official Spring AI integration of IBM watsonx.ai platform. This is a complementary project of the https://github.com/IBM/watsonx-ai-java-sdk