### PR TITLE
Add BoxLang AI to Agent Frameworks & Libraries

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -487,6 +487,11 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - **Description:** Alibaba Cloud's production-ready framework for agentic, workflow, and multi-agent Java applications, built on top of Spring AI. Graph-based orchestration (`SequentialAgent`, `ParallelAgent`, `RoutingAgent`, `LoopAgent`), multimodal ReactAgent support, MCP integration, and a built-in Admin observability/eval console. JDK 17+, Apache 2.0.
 - **Links:** [GitHub](https://github.com/alibaba/spring-ai-alibaba)
 
+### BoxLang AI
+- **Badge:** Framework
+- **Description:** Unified AI platform for the JVM from Ortus Solutions (makers of BoxLang and ColdBox). One API across 15+ providers, plus multi-agent orchestration with parent-child hierarchies, an Agent Skills system implementing Anthropic's open standard, MCP support (consuming and serving), 20+ memory types with vector RAG, and a composable middleware pipeline. Reached v3.0 in 2026. Apache 2.0.
+- **Links:** [Website](https://ai.boxlang.io/) · [Docs](https://ai.ortusbooks.com) · [GitHub](https://github.com/ortus-boxlang/bx-ai)
+
 ---
 
 ## Java with Code Assistants

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     "description": "The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.",
     "isPartOf": {"@id": "https://ai4jvm.com/#website"},
     "inLanguage": "en-US",
-    "dateModified": "2026-08-23",
+    "dateModified": "2026-08-25",
     "primaryImageOfPage": {
       "@type": "ImageObject",
       "url": "https://ai4jvm.com/og-image.png",
@@ -153,7 +153,8 @@
       {"@type": "ListItem", "position": 61, "name": "Google ADK for Kotlin", "url": "https://adk.dev/"},
       {"@type": "ListItem", "position": 62, "name": "LLM4S", "url": "https://llm4s.org/"},
       {"@type": "ListItem", "position": 63, "name": "Agents-Flex", "url": "https://github.com/agents-flex/agents-flex"},
-      {"@type": "ListItem", "position": 64, "name": "Spring AI Alibaba", "url": "https://github.com/alibaba/spring-ai-alibaba"}
+      {"@type": "ListItem", "position": 64, "name": "Spring AI Alibaba", "url": "https://github.com/alibaba/spring-ai-alibaba"},
+      {"@type": "ListItem", "position": 65, "name": "BoxLang AI", "url": "https://ai.boxlang.io/"}
     ]
   }
   </script>
@@ -1269,6 +1270,16 @@
         <p>Alibaba Cloud's production-ready framework for agentic, workflow, and multi-agent Java applications, built on top of Spring AI. Graph-based orchestration (<code>SequentialAgent</code>, <code>ParallelAgent</code>, <code>RoutingAgent</code>, <code>LoopAgent</code>), multimodal ReactAgent support, MCP integration, and a built-in Admin observability/eval console. JDK 17+, Apache 2.0.</p>
         <div class="card-links">
           <a class="icon icon-github" href="https://github.com/alibaba/spring-ai-alibaba" title="GitHub"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-framework">Framework</span>
+        <h3><a href="https://ai.boxlang.io/">BoxLang AI</a></h3>
+        <p>Unified AI platform for the JVM from Ortus Solutions (makers of BoxLang and ColdBox). One API across 15+ providers, plus multi-agent orchestration with parent-child hierarchies, an Agent Skills system implementing Anthropic's open standard, MCP support (consuming and serving), 20+ memory types with vector RAG, and a composable middleware pipeline. Reached v3.0 in 2026. Apache 2.0.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://ai.ortusbooks.com" title="Docs"></a>
+          <a class="icon icon-github" href="https://github.com/ortus-boxlang/bx-ai" title="GitHub"></a>
         </div>
       </div>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -387,6 +387,11 @@ Open-source frameworks and SDKs for building AI-powered applications on the JVM 
 - **Description:** Alibaba Cloud's production-ready framework for agentic, workflow, and multi-agent Java applications, built on top of Spring AI. Graph-based orchestration (`SequentialAgent`, `ParallelAgent`, `RoutingAgent`, `LoopAgent`), multimodal ReactAgent support, MCP integration, and a built-in Admin observability/eval console. JDK 17+, Apache 2.0.
 - **Links:** [GitHub](https://github.com/alibaba/spring-ai-alibaba)
 
+### BoxLang AI
+- **Badge:** Framework
+- **Description:** Unified AI platform for the JVM from Ortus Solutions (makers of BoxLang and ColdBox). One API across 15+ providers, plus multi-agent orchestration with parent-child hierarchies, an Agent Skills system implementing Anthropic's open standard, MCP support (consuming and serving), 20+ memory types with vector RAG, and a composable middleware pipeline. Reached v3.0 in 2026. Apache 2.0.
+- **Links:** [Website](https://ai.boxlang.io/) · [Docs](https://ai.ortusbooks.com) · [GitHub](https://github.com/ortus-boxlang/bx-ai)
+
 ## Java with Code Assistants
 
 Technologies that supercharge Java development when paired with AI code assistants — from MCP servers that give agents live Javadoc access, to reusable skill packages and IDE integrations.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-23</lastmod>
+    <lastmod>2026-08-25</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Added **BoxLang AI** (Ortus Solutions) to Agent Frameworks & Libraries in `SPEC.md`, `index.html`, and `llms-full.txt` — a JVM-native unified AI platform (15+ providers, multi-agent orchestration, Agent Skills, MCP support) that reached v3.0 in 2026 and wasn't yet listed
- Bumped `sitemap.xml`'s `<lastmod>` and `index.html`'s `CollectionPage` `dateModified` to match

## Governance-policy checks (per `.factory/DAILY.md`)
- **SEO** — spot-checked `SPEC.md`'s SEO section (meta tags, JSON-LD, heading hierarchy, `llms.txt`/`llms-full.txt` sync) against `index.html`; all already conformant, no gaps found
- **Agent-friendliness** — ran the [isitagentready.com](https://isitagentready.com) scanner against the live site. `robots.txt`, sitemap, and AI-bot/Content-Signal rules all pass. Remaining fails are infrastructure-level and out of scope for a static, no-build site with no auth/MCP-server surface of its own: DNS-AID records and OAuth/MCP/A2A/agent-skills discovery endpoints (the doc notes "the auth parts don't matter because the site is public")
- **Page speed** — the PageSpeed Insights API returned a quota-exhausted error for this environment (no API key available), so I did a manual Lighthouse-heuristic pass instead: all 57 avatar images already have explicit sizing, `loading="lazy"`, and `decoding="async"`; no web fonts; CSS is a single inline block; Google Analytics tag is async and last in `<head>`. No changes needed.

## Test plan
- [x] Reviewed the rendered diff of `index.html` for correct card markup, badge, and link icons matching the existing pattern
- [x] Verified the new `ItemList` entry's position number and `llms-full.txt` entry match `SPEC.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01SE2heAQMvJ3sUzCjagxUNz)_