### PR TITLE
Governance review: refresh news, fix People alphabetical order

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -108,6 +108,8 @@ Questions and answers:
 Latest headlines about the Java AI ecosystem. Each item has a link and brief description.
 Note: Order by date, newest first. Don't show news older than 3 months
 
+- https://github.com/embabel/embabel-agent/releases/tag/v1.5.1
+- https://micronaut.io/2026/08/24/micronaut-framework-5-1-2/
 - https://spring.io/blog/2026/08/21/spring-ai-2-0-1-available-now/
 - https://github.com/modelcontextprotocol/java-sdk/releases/tag/v2.0.1
 - https://quarkus.io/blog/a2a-java-sdk-1-2-0-final-released/
@@ -161,7 +163,6 @@ Note: Order by date, newest first. Don't show news older than 3 months
 - https://java.agentscope.io/v2/en/blogs/agentscope-v2-release.html
 - https://javapro.io/2026/06/03/the-gen-ai-iceberg-java-tooling-edition/
 - https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/
-- https://quarkus.io/blog/introducing-voting-pattern/
 
 ---
 
@@ -792,15 +793,6 @@ Notes:
 - **Role:** Developer Advocate — IBM Research, JavaLand founder
 - **Links:** [@myfear](https://twitter.com/myfear) · [Bluesky](https://bsky.app/profile/myfear.com) · [GitHub](https://github.com/myfear) · [LinkedIn](https://www.linkedin.com/in/markuseisele/) · [Blog](https://blog.eisele.net/)
 
-### Mario Fusco
-
-- **Badge:** Person
-- **Java Champion**
-- **Initials:** MF
-- **Photo:** https://avatars.githubusercontent.com/u/372781?v=4
-- **Role:** LangChain4j core team, Sr. Principal Software Engineer at IBM
-- **Links:** [@mariofusco](https://x.com/mariofusco) · [GitHub](https://github.com/mariofusco) · [LinkedIn](https://www.linkedin.com/in/mario-fusco-3467213/)
-
 ### Clement Escoffier
 
 - **Badge:** Person
@@ -809,6 +801,15 @@ Notes:
 - **Photo:** https://avatars.githubusercontent.com/u/402301?v=4
 - **Role:** Red Hat Distinguished Engineer, Quarkus co-creator, works on the Quarkus LangChain4j extension
 - **Links:** [GitHub](https://github.com/cescoffier) · [foojay](https://foojay.io/today/author/clement-escoffier/)
+
+### Mario Fusco
+
+- **Badge:** Person
+- **Java Champion**
+- **Initials:** MF
+- **Photo:** https://avatars.githubusercontent.com/u/372781?v=4
+- **Role:** LangChain4j core team, Sr. Principal Software Engineer at IBM
+- **Links:** [@mariofusco](https://x.com/mariofusco) · [GitHub](https://github.com/mariofusco) · [LinkedIn](https://www.linkedin.com/in/mario-fusco-3467213/)
 
 ### Antonio Goncalves
 

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     "description": "The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.",
     "isPartOf": {"@id": "https://ai4jvm.com/#website"},
     "inLanguage": "en-US",
-    "dateModified": "2026-08-25",
+    "dateModified": "2026-08-26",
     "primaryImageOfPage": {
       "@type": "ImageObject",
       "url": "https://ai4jvm.com/og-image.png",
@@ -231,8 +231,8 @@
       {"@type": "ListItem", "position": 11, "item": {"@type": "Person", "name": "Iryna Dohndorf", "url": "https://github.com/IDohndorf"}},
       {"@type": "ListItem", "position": 12, "item": {"@type": "Person", "name": "Julien Dubois", "url": "https://twitter.com/juliendubois"}},
       {"@type": "ListItem", "position": 13, "item": {"@type": "Person", "name": "Markus Eisele", "url": "https://twitter.com/myfear"}},
-      {"@type": "ListItem", "position": 14, "item": {"@type": "Person", "name": "Mario Fusco", "url": "https://x.com/mariofusco"}},
-      {"@type": "ListItem", "position": 15, "item": {"@type": "Person", "name": "Clement Escoffier", "url": "https://github.com/cescoffier"}},
+      {"@type": "ListItem", "position": 14, "item": {"@type": "Person", "name": "Clement Escoffier", "url": "https://github.com/cescoffier"}},
+      {"@type": "ListItem", "position": 15, "item": {"@type": "Person", "name": "Mario Fusco", "url": "https://x.com/mariofusco"}},
       {"@type": "ListItem", "position": 16, "item": {"@type": "Person", "name": "Antonio Goncalves", "url": "https://twitter.com/agoncal"}},
       {"@type": "ListItem", "position": 17, "item": {"@type": "Person", "name": "Ilayaperumal Gopinathan", "url": "https://github.com/ilayaperumalg"}},
       {"@type": "ListItem", "position": 18, "item": {"@type": "Person", "name": "Frank Greco", "url": "https://twitter.com/frankgreco"}},
@@ -574,6 +574,8 @@
       <h2 class="section-title" style="font-size:1.1rem;margin-bottom:.75rem;">Latest Java AI News</h2>
       <p class="section-subtitle" style="margin-bottom:.75rem;">Latest news and releases from across the Java AI ecosystem &mdash; new framework versions, MCP updates, and inference engines.</p>
       <ul>
+        <li><a href="https://github.com/embabel/embabel-agent/releases/tag/v1.5.1">Embabel Agent 1.5.1 Released</a> &mdash; RAG improvements including a <code>SectionReader</code> for document navigation, embedding-driven skills, Atlas Cloud BYOK support, thinking-tag selection control, and fixes for Bedrock chat options and Ollama thinking-mode extraction</li>
+        <li><a href="https://micronaut.io/2026/08/24/micronaut-framework-5-1-2/">Micronaut Framework 5.1.2 Released</a> &mdash; maintenance release with updates across Core, Cache, Test, Data, Security, Serialization, and Flyway modules</li>
         <li><a href="https://spring.io/blog/2026/08/21/spring-ai-2-0-1-available-now/">Spring AI 2.0.1 Available Now</a> &mdash; first maintenance release since the June 2.0.0 GA, fixing 80+ issues including 7 CVEs (PDF processing, cache, session allocation, file operations, semantic caching, Redis, tool dispatch), adding configurable tool-call limits and OpenAI audio streaming, and removing deprecated Mistral AI chat models</li>
         <li><a href="https://github.com/modelcontextprotocol/java-sdk/releases/tag/v2.0.1">MCP Java SDK 2.0.1 Released</a> &mdash; first patch on the 2.0 line: upgrades the conformance suite to 0.1.16 and Spring AI conformance to 2.0.0 GA, bounds HTTP and STDIO server/client reads, and fixes SSE event classification, pagination, and unregistered-handler behavior in stateless servers</li>
         <li><a href="https://quarkus.io/blog/a2a-java-sdk-1-2-0-final-released/">A2A Java SDK 1.2.0.Final Released</a> &mdash; hardens the authorization model with read-authorization enforcement on referenced task lookups, adds a <code>TaskStreamLifecycleHook</code> SPI for stream lifecycle management, and ships breaking changes including method renames and a <code>TaskState</code> enum change</li>
@@ -627,7 +629,6 @@
         <li><a href="https://java.agentscope.io/v2/en/blogs/agentscope-v2-release.html">AgentScope Java v2.0.0 GA</a> &mdash; Alibaba's JVM-native agent framework reaches production-ready GA, with event-streaming, permission-gated tool execution, and a Workspace abstraction for long-running, safely sandboxed agents</li>
         <li><a href="https://javapro.io/2026/06/03/the-gen-ai-iceberg-java-tooling-edition/">The Gen AI Iceberg: Java Tooling Edition</a> &mdash; a tiered tour of Java's generative AI tooling, from mainstream frameworks like Spring AI and LangChain4j down to GPU kernel compilation and Project Babylon, arguing the JVM runs AI workloads natively rather than just calling out to them</li>
         <li><a href="https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/">Koog 1.0 Is Out</a> &mdash; JetBrains' Kotlin/Java agent framework reaches a stable core with a 1-year API guarantee, a redesigned Java interop layer, decoupled HTTP transport, and OpenTelemetry observability</li>
-        <li><a href="https://quarkus.io/blog/introducing-voting-pattern/">Parallel Voting and Adaptive Model Selection in Quarkus</a> &mdash; LangChain4j's new voting pattern dispatches tasks to multiple evaluator agents in parallel and aggregates results, paired with dynamic chat model switching to balance cost and quality in agentic workflows</li>
       </ul>
     </div>
   </div>
@@ -1796,6 +1797,19 @@
       </div>
 
       <div class="person">
+        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/402301?v=4&amp;s=96" alt="Clement Escoffier" width="48" height="48" loading="lazy" decoding="async"></div>
+        <div class="person-info">
+          <h3>Clement Escoffier</h3>
+          <span class="badge-champion">Java Champion</span>
+          <p>Red Hat Distinguished Engineer, Quarkus co-creator, works on the Quarkus LangChain4j extension</p>
+          <div class="person-links">
+            <a class="icon icon-github" href="https://github.com/cescoffier" title="GitHub"></a>
+            <a class="icon icon-web" href="https://foojay.io/today/author/clement-escoffier/" title="foojay"></a>
+          </div>
+        </div>
+      </div>
+
+      <div class="person">
         <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/372781?v=4&amp;s=96" alt="Mario Fusco" width="48" height="48" loading="lazy" decoding="async"></div>
         <div class="person-info">
           <h3>Mario Fusco</h3>
@@ -1805,19 +1819,6 @@
             <a class="icon icon-x" href="https://x.com/mariofusco" title="@mariofusco"></a>
             <a class="icon icon-github" href="https://github.com/mariofusco" title="GitHub"></a>
             <a class="icon icon-linkedin" href="https://www.linkedin.com/in/mario-fusco-3467213/" title="LinkedIn"></a>
-          </div>
-        </div>
-      </div>
-
-      <div class="person">
-        <div class="person-avatar"><img src="https://avatars.githubusercontent.com/u/402301?v=4&amp;s=96" alt="Clement Escoffier" width="48" height="48" loading="lazy" decoding="async"></div>
-        <div class="person-info">
-          <h3>Clement Escoffier</h3>
-          <span class="badge-champion">Java Champion</span>
-          <p>Red Hat Distinguished Engineer, Quarkus co-creator, works on the Quarkus LangChain4j extension</p>
-          <div class="person-links">
-            <a class="icon icon-github" href="https://github.com/cescoffier" title="GitHub"></a>
-            <a class="icon icon-web" href="https://foojay.io/today/author/clement-escoffier/" title="foojay"></a>
           </div>
         </div>
       </div>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,6 +8,8 @@ Complete content of https://ai4jvm.com/ in Markdown. This is the full directory;
 
 Latest news and releases from across the Java AI ecosystem — new framework versions, MCP updates, and inference engines.
 
+- [Embabel Agent 1.5.1 Released](https://github.com/embabel/embabel-agent/releases/tag/v1.5.1) — RAG improvements including a `SectionReader` for document navigation, embedding-driven skills, Atlas Cloud BYOK support, thinking-tag selection control, and fixes for Bedrock chat options and Ollama thinking-mode extraction
+- [Micronaut Framework 5.1.2 Released](https://micronaut.io/2026/08/24/micronaut-framework-5-1-2/) — maintenance release with updates across Core, Cache, Test, Data, Security, Serialization, and Flyway modules
 - [Spring AI 2.0.1 Available Now](https://spring.io/blog/2026/08/21/spring-ai-2-0-1-available-now/) — first maintenance release since the June 2.0.0 GA, fixing 80+ issues including 7 CVEs (PDF processing, cache, session allocation, file operations, semantic caching, Redis, tool dispatch), adding configurable tool-call limits and OpenAI audio streaming, and removing deprecated Mistral AI chat models
 - [MCP Java SDK 2.0.1 Released](https://github.com/modelcontextprotocol/java-sdk/releases/tag/v2.0.1) — first patch on the 2.0 line: upgrades the conformance suite to 0.1.16 and Spring AI conformance to 2.0.0 GA, bounds HTTP and STDIO server/client reads, and fixes SSE event classification, pagination, and unregistered-handler behavior in stateless servers
 - [A2A Java SDK 1.2.0.Final Released](https://quarkus.io/blog/a2a-java-sdk-1-2-0-final-released/) — hardens the authorization model with read-authorization enforcement on referenced task lookups, adds a `TaskStreamLifecycleHook` SPI for stream lifecycle management, and ships breaking changes including method renames and a `TaskState` enum change
@@ -61,7 +63,6 @@ Latest news and releases from across the Java AI ecosystem — new framework ver
 - [AgentScope Java v2.0.0 GA](https://java.agentscope.io/v2/en/blogs/agentscope-v2-release.html) — Alibaba's JVM-native agent framework reaches production-ready GA, with event-streaming, permission-gated tool execution, and a Workspace abstraction for long-running, safely sandboxed agents
 - [The Gen AI Iceberg: Java Tooling Edition](https://javapro.io/2026/06/03/the-gen-ai-iceberg-java-tooling-edition/) — a tiered tour of Java's generative AI tooling, from mainstream frameworks like Spring AI and LangChain4j down to GPU kernel compilation and Project Babylon, arguing the JVM runs AI workloads natively rather than just calling out to them
 - [Koog 1.0 Is Out](https://blog.jetbrains.com/ai/2026/05/koog-1-0-is-out-stable-core-better-interop-and-multiplatform-observability/) — JetBrains' Kotlin/Java agent framework reaches a stable core with a 1-year API guarantee, a redesigned Java interop layer, decoupled HTTP transport, and OpenTelemetry observability
-- [Parallel Voting and Adaptive Model Selection in Quarkus](https://quarkus.io/blog/introducing-voting-pattern/) — LangChain4j's new voting pattern dispatches tasks to multiple evaluator agents in parallel and aggregates results, paired with dynamic chat model switching to balance cost and quality in agentic workflows
 
 ## Agent Frameworks & Libraries
 
@@ -621,13 +622,13 @@ Key voices at the intersection of Java and AI.
 - **Bio:** Developer Advocate — IBM Research, JavaLand founder
 - **Links:** [@myfear](https://twitter.com/myfear) · [Bluesky](https://bsky.app/profile/myfear.com) · [GitHub](https://github.com/myfear) · [LinkedIn](https://www.linkedin.com/in/markuseisele/) · [Blog](https://blog.eisele.net/)
 
-### Mario Fusco (Java Champion)
-- **Bio:** LangChain4j core team, Sr. Principal Software Engineer at IBM
-- **Links:** [@mariofusco](https://x.com/mariofusco) · [GitHub](https://github.com/mariofusco) · [LinkedIn](https://www.linkedin.com/in/mario-fusco-3467213/)
-
 ### Clement Escoffier (Java Champion)
 - **Bio:** Red Hat Distinguished Engineer, Quarkus co-creator, works on the Quarkus LangChain4j extension
 - **Links:** [GitHub](https://github.com/cescoffier) · [foojay](https://foojay.io/today/author/clement-escoffier/)
+
+### Mario Fusco (Java Champion)
+- **Bio:** LangChain4j core team, Sr. Principal Software Engineer at IBM
+- **Links:** [@mariofusco](https://x.com/mariofusco) · [GitHub](https://github.com/mariofusco) · [LinkedIn](https://www.linkedin.com/in/mario-fusco-3467213/)
 
 ### Antonio Goncalves (Java Champion)
 - **Bio:** Principal Software Engineer at Microsoft CoreAI, ParisJUG, Devoxx France, Café IA, book author

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-25</lastmod>
+    <lastmod>2026-08-26</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
- Add Embabel Agent 1.5.1 and Micronaut Framework 5.1.2 releases to the News section (SPEC.md, index.html, llms-full.txt)
- Drop the May 22 Quarkus voting-pattern post, now past the 3-month freshness window
- Reorder Clement Escoffier before Mario Fusco in People to Follow to match SPEC.md's "alphabetical by last name" rule — fixed in index.html's rendered cards, the People `ItemList` JSON-LD positions, and llms-full.txt
- Bump `dateModified` (index.html) / `<lastmod>` (sitemap.xml) to today

## Audit performed (per `.factory/DAILY.md`)
- Checked all open PRs first — none were for this recurring governance-review work, so this is a new PR
- Full SEO/structured-data conformance pass against SPEC.md's SEO section: ItemList↔card sync (all 4 sections), FAQPage schema, heading hierarchy, avatar image attributes (all 57 checked), sitemap/dateModified sync, robots.txt crawler rules, llms.txt/llms-full.txt sync, and `<head>` element ordering — all confirmed OK except the People ordering slip fixed above
- Checked ecosystem projects for new activity in the Aug 21–26 window — only the two items above qualified as genuinely new Java/JVM AI tooling news
- Google's public PageSpeed Insights API returned a daily quota-exceeded error, so a fresh live score couldn't be pulled today; SPEC.md's existing performance rules (no web fonts, sized/lazy/async avatars, preconnect, inline CSS, GA tag last in `<head>`) were verified as already implemented
- isitagentready.com's criteria beyond robots.txt/sitemap/Content-Signal (already implemented per SPEC.md) cover auth/commerce protocols (OAuth discovery, x402, MPP, UCP, ACP) that don't apply to this public, static content directory

## Test plan
- [ ] Validated all 7 JSON-LD blocks in index.html parse as valid JSON
- [ ] Visually confirm the News section and People to Follow section render correctly

---
_Generated by [Claude Code](https://claude.ai/code/session_013ggWzvuK9PLku7YBQDgChe)_