### PR TITLE
Add ModelJARs to ML inference frameworks guide

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -658,6 +658,11 @@ Run models, train classifiers, and do ML inference directly on the JVM — no Py
 - **Description:** GPU programming framework for Java — JIT-compiles Java bytecode into CUDA, OpenCL, and Apple Metal at runtime, running on GPUs and multi-core CPUs. Powers GPULlama3.java's GPU acceleration. v5.2.0 added AI-focused kernels: native FP8 conversion, FP8/BF16 tensor-core matrix multiply, cuBLAS/CUTLASS-compatible BFloat16 arrays, and batched FP16 GEMM. From the University of Manchester's Beehive Lab.
 - **Links:** [Website](https://www.tornadovm.org) · [GitHub](https://github.com/beehive-lab/TornadoVM) · [Docs](https://tornadovm.readthedocs.io/en/latest/)
 
+### ModelJARs
+- **Badge:** Inference
+- **Description:** Community registry that publishes AI models as versioned marker JARs, so a model becomes an ordinary Maven or Gradle dependency (`org.modeljars.huggingface:…`) pinned by SHA-256 to an immutable Hugging Face revision instead of vendored weights. Covers GGUF, Safetensors, and CACT artifacts, and ships a native CLI for search/pull plus the Java 25 Models runtime for in-process inference, with pure-Java Vector API, native, TornadoVM GPU, and Apple Foundation Models backends. Maintainers qualify each artifact in CI and publish benchmarks against llama.cpp and Ollama. From Integrallis.
+- **Links:** [Website](https://modeljars.org/) · [GitHub](https://github.com/ModelJars/modeljars) · [Docs](https://integrallis.github.io/models/docs/models/current/index.html) · [Benchmarks](https://modeljars.org/benchmarks/)
+
 ### TensorFlow Java
 - **Badge:** Training
 - **Description:** Java bindings for TensorFlow, maintained by the TensorFlow JVM SIG. Train and deploy TF models entirely in Java. Available as an optional Tribuo integration. Suitable for teams that want to stay within the JVM ecosystem while using TensorFlow's model formats.

--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
     "description": "The curated guide to AI on the JVM — compare Java AI agent frameworks (Spring AI, LangChain4j, Koog), run LLMs locally, and find MCP tools and resources.",
     "isPartOf": {"@id": "https://ai4jvm.com/#website"},
     "inLanguage": "en-US",
-    "dateModified": "2026-08-28",
+    "dateModified": "2026-08-31",
     "primaryImageOfPage": {
       "@type": "ImageObject",
       "url": "https://ai4jvm.com/og-image.png",
@@ -205,9 +205,10 @@
       {"@type": "ListItem", "position": 5, "name": "Tribuo", "url": "https://tribuo.org/"},
       {"@type": "ListItem", "position": 6, "name": "GPULlama3.java", "url": "https://github.com/beehive-lab/GPULlama3.java"},
       {"@type": "ListItem", "position": 7, "name": "TornadoVM", "url": "https://www.tornadovm.org"},
-      {"@type": "ListItem", "position": 8, "name": "TensorFlow Java", "url": "https://www.tensorflow.org/jvm"},
-      {"@type": "ListItem", "position": 9, "name": "Eclipse Deeplearning4j (DL4J)", "url": "https://deeplearning4j.konduit.ai/"},
-      {"@type": "ListItem", "position": 10, "name": "Apache OpenNLP", "url": "https://opennlp.apache.org"}
+      {"@type": "ListItem", "position": 8, "name": "ModelJARs", "url": "https://modeljars.org/"},
+      {"@type": "ListItem", "position": 9, "name": "TensorFlow Java", "url": "https://www.tensorflow.org/jvm"},
+      {"@type": "ListItem", "position": 10, "name": "Eclipse Deeplearning4j (DL4J)", "url": "https://deeplearning4j.konduit.ai/"},
+      {"@type": "ListItem", "position": 11, "name": "Apache OpenNLP", "url": "https://opennlp.apache.org"}
     ]
   }
   </script>
@@ -1567,6 +1568,18 @@
           <a class="icon icon-web" href="https://www.tornadovm.org" title="Website"></a>
           <a class="icon icon-github" href="https://github.com/beehive-lab/TornadoVM" title="GitHub"></a>
           <a class="icon icon-web" href="https://tornadovm.readthedocs.io/en/latest/" title="Docs"></a>
+        </div>
+      </div>
+
+      <div class="card">
+        <span class="card-badge badge-inference">Inference</span>
+        <h3><a href="https://modeljars.org/">ModelJARs</a></h3>
+        <p>Community registry that publishes AI models as versioned marker JARs, so a model becomes an ordinary Maven or Gradle dependency (<code>org.modeljars.huggingface:&hellip;</code>) pinned by SHA-256 to an immutable Hugging Face revision instead of vendored weights. Covers GGUF, Safetensors, and CACT artifacts, and ships a native CLI for search/pull plus the Java 25 Models runtime for in-process inference, with pure-Java Vector API, native, TornadoVM GPU, and Apple Foundation Models backends. Maintainers qualify each artifact in CI and publish benchmarks against llama.cpp and Ollama. From Integrallis.</p>
+        <div class="card-links">
+          <a class="icon icon-web" href="https://modeljars.org/" title="Website"></a>
+          <a class="icon icon-github" href="https://github.com/ModelJars/modeljars" title="GitHub"></a>
+          <a class="icon icon-web" href="https://integrallis.github.io/models/docs/models/current/index.html" title="Docs"></a>
+          <a class="icon icon-web" href="https://modeljars.org/benchmarks/" title="Benchmarks"></a>
         </div>
       </div>
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -553,6 +553,11 @@ Run models, train classifiers, and do ML inference directly on the JVM — no Py
 - **Description:** GPU programming framework for Java — JIT-compiles Java bytecode into CUDA, OpenCL, and Apple Metal at runtime, running on GPUs and multi-core CPUs. Powers GPULlama3.java's GPU acceleration. v5.2.0 added AI-focused kernels: native FP8 conversion, FP8/BF16 tensor-core matrix multiply, cuBLAS/CUTLASS-compatible BFloat16 arrays, and batched FP16 GEMM. From the University of Manchester's Beehive Lab.
 - **Links:** [Website](https://www.tornadovm.org) · [GitHub](https://github.com/beehive-lab/TornadoVM) · [Docs](https://tornadovm.readthedocs.io/en/latest/)
 
+### ModelJARs
+- **Badge:** Inference
+- **Description:** Community registry that publishes AI models as versioned marker JARs, so a model becomes an ordinary Maven or Gradle dependency (`org.modeljars.huggingface:…`) pinned by SHA-256 to an immutable Hugging Face revision instead of vendored weights. Covers GGUF, Safetensors, and CACT artifacts, and ships a native CLI for search/pull plus the Java 25 Models runtime for in-process inference, with pure-Java Vector API, native, TornadoVM GPU, and Apple Foundation Models backends. Maintainers qualify each artifact in CI and publish benchmarks against llama.cpp and Ollama. From Integrallis.
+- **Links:** [Website](https://modeljars.org/) · [GitHub](https://github.com/ModelJars/modeljars) · [Docs](https://integrallis.github.io/models/docs/models/current/index.html) · [Benchmarks](https://modeljars.org/benchmarks/)
+
 ### TensorFlow Java
 - **Badge:** Training
 - **Description:** Java bindings for TensorFlow, maintained by the TensorFlow JVM SIG. Train and deploy TF models entirely in Java. Available as an optional Tribuo integration. Suitable for teams that want to stay within the JVM ecosystem while using TensorFlow's model formats.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://ai4jvm.com/</loc>
-    <lastmod>2026-08-28</lastmod>
+    <lastmod>2026-08-31</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>


### PR DESCRIPTION
## Summary
Add ModelJARs, a community registry for publishing AI models as Maven/Gradle dependencies, to the AI4JVM guide as a new inference framework option.

## Changes
- **index.html**: Added ModelJARs card (position 8) in the ML frameworks section with badge, description, and links to website, GitHub, docs, and benchmarks. Reordered subsequent frameworks and updated `dateModified` to 2026-08-31.
- **SPEC.md & llms-full.txt**: Added ModelJARs entry in the "Run models, train classifiers..." section with full description and reference links.
- **sitemap.xml**: Updated `lastmod` timestamp to 2026-08-31.

## Details
ModelJARs is positioned as an inference framework that enables AI models to be consumed as versioned Maven/Gradle dependencies (e.g., `org.modeljars.huggingface:…`) pinned to immutable Hugging Face revisions. The entry highlights support for GGUF, Safetensors, and CACT artifacts, plus multiple inference backends (pure-Java Vector API, native, TornadoVM GPU, and Apple Foundation Models). Includes links to benchmarks comparing against llama.cpp and Ollama.

https://claude.ai/code/session_01Lug29Q1pmNJ5KcfWV4sMxY